### PR TITLE
CSHARP-2460: Add throwing exception if linq expressions use unreachable query members.

### DIFF
--- a/src/MongoDB.Driver/Linq/Expressions/FieldExpression.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/FieldExpression.cs
@@ -20,7 +20,7 @@ using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Linq.Expressions
 {
-    internal sealed class FieldExpression : SerializationExpression, IFieldExpression
+    internal sealed class FieldExpression : SerializationExpression, IFieldExpression, IExpressionMemberInfo
     {
         private readonly Expression _document;
         private readonly string _fieldName;
@@ -69,6 +69,8 @@ namespace MongoDB.Driver.Linq.Expressions
         {
             get { return _original; }
         }
+
+        public string OutOfCurrentScopePrefix { get; set; }
 
         public override IBsonSerializer Serializer
         {

--- a/src/MongoDB.Driver/Linq/Expressions/IExpressionMemberInfo.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/IExpressionMemberInfo.cs
@@ -1,0 +1,22 @@
+﻿/* Copyright 2019-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.Linq.Expressions
+{
+    internal interface IExpressionMemberInfo
+    {
+        string OutOfCurrentScopePrefix { get; set; }
+    }
+}

--- a/src/MongoDB.Driver/Linq/Processors/ExpressionInfoCollector.cs
+++ b/src/MongoDB.Driver/Linq/Processors/ExpressionInfoCollector.cs
@@ -1,0 +1,53 @@
+﻿/* Copyright 2019-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using MongoDB.Driver.Linq.Expressions;
+
+namespace MongoDB.Driver.Linq.Processors
+{
+    /// <summary>
+    /// The expression visitor to collect all parameters in the expression.
+    /// </summary>
+    internal sealed class ExpressionInfoCollector : ExtensionExpressionVisitor
+    {
+        private readonly List<IExpressionMemberInfo> _expressionNodeInfoCollection = new List<IExpressionMemberInfo>();
+
+        /// <summary>
+        /// Collects the list of node information.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <returns>The result collection.</returns>
+        public static IEnumerable<IExpressionMemberInfo> Collect(Expression expression)
+        {
+            var parameterCollector = new ExpressionInfoCollector();
+            parameterCollector.Visit(expression);
+            return parameterCollector._expressionNodeInfoCollection.Distinct();
+        }
+
+        public override Expression Visit(Expression node)
+        {
+            var memberInfo = node as IExpressionMemberInfo;
+            if (memberInfo != null)
+            {
+                _expressionNodeInfoCollection.Add(memberInfo);
+            }
+
+            return base.Visit(node);
+        }
+    }
+}

--- a/src/MongoDB.Driver/Linq/Processors/SerializationBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/SerializationBinder.cs
@@ -15,14 +15,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Linq.Expressions;
 using MongoDB.Driver.Linq.Processors.EmbeddedPipeline;
-using MongoDB.Driver.Support;
 
 namespace MongoDB.Driver.Linq.Processors
 {
@@ -37,6 +35,7 @@ namespace MongoDB.Driver.Linq.Processors
         private readonly IBindingContext _bindingContext;
         private bool _isInEmbeddedPipeline;
         private readonly bool _isClientSideProjection;
+        private bool _isOutOfCurrentScope;
 
         private SerializationBinder(IBindingContext bindingContext, bool isClientSideProjection)
         {
@@ -103,12 +102,21 @@ namespace MongoDB.Driver.Linq.Processors
 
         protected override Expression VisitLambda<T>(Expression<T> node)
         {
+            var oldIsOutOfCurrentScope = _isOutOfCurrentScope;
+            if (_isInEmbeddedPipeline)
+            {
+                _isOutOfCurrentScope = true;
+            }
+
             // Don't visit the parameters. We cannot replace a parameter expression
             // with a document and we don't have a new parameter type to use because
             // we don't know why we are binding yet.
-            return node.Update(
+            var result = node.Update(
                 Visit(node.Body),
                 node.Parameters);
+            _isOutOfCurrentScope = oldIsOutOfCurrentScope;
+
+            return result;
         }
 
         protected override Expression VisitMember(MemberExpression node)
@@ -151,6 +159,10 @@ namespace MongoDB.Driver.Linq.Processors
                                 mex);
                         }
                     }
+
+                    var rawParameterExpression = (node.Expression as ParameterExpression);
+                    if (_isOutOfCurrentScope && rawParameterExpression != null)
+                        SaveOutOfScopePrefix(newNode, rawParameterExpression.Name);
                 }
             }
 
@@ -396,6 +408,15 @@ namespace MongoDB.Driver.Linq.Processors
             }
 
             return node;
+        }
+
+        private void SaveOutOfScopePrefix(Expression expression, string value)
+        {
+            var memberInfo = expression as IExpressionMemberInfo;
+            if (memberInfo != null)
+            {
+                memberInfo.OutOfCurrentScopePrefix = value;
+            }
         }
     }
 }

--- a/src/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
@@ -921,6 +921,8 @@ namespace MongoDB.Driver.Linq.Translators
                 return null;
             }
 
+            ValidatePipelineExpressionThrowIfNotValid(whereExpression);
+
             FilterDefinition<BsonDocument> filter;
             var renderWithoutElemMatch = CanAnyBeRenderedWithoutElemMatch(whereExpression.Predicate);
 
@@ -1651,6 +1653,16 @@ namespace MongoDB.Driver.Linq.Translators
             }
 
             return fieldExpression;
+        }
+
+        private void ValidatePipelineExpressionThrowIfNotValid(WhereExpression whereExpression)
+        {
+            var memberInfoCollection = ExpressionInfoCollector.Collect(whereExpression)?.ToList();
+            var unsupportedField = memberInfoCollection?.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c.OutOfCurrentScopePrefix));
+            if (!string.IsNullOrWhiteSpace(unsupportedField?.OutOfCurrentScopePrefix))
+            {
+                throw new NotSupportedException($"The LINQ expression: {whereExpression} has the member \"{unsupportedField.OutOfCurrentScopePrefix}\" which can not be used to build a correct Mongo query");
+            }
         }
 
         // nested types

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorValidationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorValidationTests.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver.Linq;
+using Xunit;
+
+namespace MongoDB.Driver.Tests.Linq.Translators
+{
+    public class PredicateTranslatorValidationTests
+    {
+        private readonly IMongoCollection<TestObject> _collection;
+
+        public PredicateTranslatorValidationTests()
+        {
+            var connectionString = CoreTestConfiguration.ConnectionString.ToString();
+            IMongoClient client = new MongoClient(connectionString);
+            var database = client.GetDatabase("test");
+            _collection = database.GetCollection<TestObject>("testObject");
+            database.DropCollection("testObject");
+        }
+
+        private class TestObject
+        {
+            public int Value1 { get; set; }
+            public bool Value2 { get; set; }
+            public IEnumerable<TestObject> Collection1 { get; set; }
+            public IEnumerable<int> Collection2 { get; set; }
+            public IEnumerable<bool> Collection3 { get; set; }
+        }
+
+        private const string NotSupportErrorMessageTemplate = "The LINQ expression: {0} has the member \"{1}\" which can not be used to build a correct Mongo query";
+
+        [Fact]
+        public void Should_not_throw_the_exception_when_a_child_expression_is_called_from_locals()
+        {
+            var local = new List<int> { 1, 2 };
+
+            Expression<Func<TestObject, bool>> expr = (a) => local.Any(b => a.Collection2.Contains(b));
+            Execute(CreateWhereQuery(expr));
+        }
+
+        [Fact]
+        public void Should_not_throw_the_exception_when_a_predicate_has_only_parameter_expressions()
+        {
+            Expression<Func<TestObject, bool>> expr = (a) => a.Collection3.Any(b => b);
+            Execute(CreateWhereQuery(expr));
+
+            expr = (a) => a.Collection3.Any(b => b && b);
+            Execute(CreateWhereQuery(expr));
+        }
+
+        [Fact]
+        public void Should_not_throw_the_exception_when_there_are_no_parent_parameters_in_child_expressions()
+        {
+            Expression<Func<TestObject, bool>> expr =
+                (a) =>
+                    a.Collection1
+                        .Where(b => b.Collection1.Any(d => d.Value1 != 2))
+                        .Any(c => c.Value1 == 3);
+
+            Execute(CreateWhereQuery(expr));
+        }
+
+        [Fact]
+        public void Should_not_throw_the_exception_when_there_are_several_conditions_and_there_are_no_parent_parameters_in_children()
+        {
+            Expression<Func<TestObject, bool>> expr =
+                (a) =>
+                    a.Collection1.Any(c => c.Value1 == 3) &&
+                    a.Collection1.Any(d => d.Value1 != 4);
+            Execute(CreateWhereQuery(expr));
+
+            expr =
+                (a) => a.Collection1
+                    .Any(
+                        c => c.Value1 != 3 && c.Collection1.Any(d => d.Value1 != 5));
+            Execute(CreateWhereQuery(expr));
+        }
+
+
+        [Fact]
+        public void Should_not_throw_the_exception_when_top_method_is_called_from_other_linq_method_and_there_is_no_any_using_of_cross_levels_parameters()
+        {
+            Execute(CreateQuery().Select(x => x.Collection1).Where(x => x.Any(y => y.Value1 > 1)));
+        }
+
+        [Fact]
+        public void Should_not_throw_the_exception_when_top_method_is_not_where_predicate()
+        {
+            Execute(CreateQuery().Select(x => x.Collection1.Where(y => y.Value1 > x.Value1)));
+
+            Execute(CreateQuery().GroupBy(x => x.Collection1.Where(y => y.Value1 > x.Value1)));
+        }
+
+        [Fact]
+        public void Should_throw_the_exception_when_a_child_expression_uses_parameters_from_grandparents()
+        {
+            Expression<Func<TestObject, bool>> expr = (a) => a.Collection1.Any(b => b.Collection1.Any(c => a.Value1 == 2));
+
+            var exception = Assert.Throws<NotSupportedException>(() => Execute(CreateWhereQuery(expr)));
+            exception.Message.Should().Be(string.Format(NotSupportErrorMessageTemplate, "{document}{Collection1#null}.Where(Any({document}{Collection1#null}.Where(({document}{Value1#a} == 2))))", "a"));
+        }
+
+        [Fact]
+        public void Should_throw_the_exception_when_a_child_expression_uses_parameters_from_parents()
+        {
+            Expression<Func<TestObject, bool>> expr = (a) => a.Collection1.Any(b => a.Value1 == 2);
+            var exception = Assert.Throws<NotSupportedException>(() => Execute(CreateWhereQuery(expr)));
+            exception.Message.Should().Be(string.Format(NotSupportErrorMessageTemplate, "{document}{Collection1#null}.Where(({document}{Value1#a} == 2))", "a"));
+
+            expr = (a) => a.Collection1.Any(b => b.Value1 == 2 && a.Value1 == 3);
+            exception = Assert.Throws<NotSupportedException>(() => Execute(CreateWhereQuery(expr)));
+            exception.Message.Should().Be(string.Format(NotSupportErrorMessageTemplate, "{document}{Collection1#null}.Where((({document}{Value1#null} == 2) AndAlso ({document}{Value1#a} == 3)))", "a"));
+
+            expr = (a) => a.Collection3.Any(b => a.Value2);
+            exception = Assert.Throws<NotSupportedException>(() => Execute(CreateWhereQuery(expr)));
+            exception.Message.Should().Be(string.Format(NotSupportErrorMessageTemplate, "{document}{Collection3#null}.Where({document}{Value2#a})", "a"));
+
+            expr = (a) => a.Collection1.Where(b => a.Value1 == 2).Any();
+            exception = Assert.Throws<NotSupportedException>(() => Execute(CreateWhereQuery(expr)));
+            exception.Message.Should().Be(string.Format(NotSupportErrorMessageTemplate, "{document}{Collection1#null}.Where(({document}{Value1#a} == 2))", "a"));
+        }
+
+        [Fact]
+        public void Should_throw_the_exception_when_there_is_the_parent_parameter_in_the_child_expression_and_there_are_several_conditions()
+        {
+            Expression<Func<TestObject, bool>> expr =
+                (a) =>
+                    a.Collection1.Any(c => c.Value1 == 3) &&
+                    a.Collection1.Any(d => a.Value1 != 4);
+            var exception = Assert.Throws<NotSupportedException>(() => Execute(CreateWhereQuery(expr)));
+            exception.Message.Should().Be(string.Format(NotSupportErrorMessageTemplate, "{document}{Collection1#null}.Where(({document}{Value1#a} != 4))", "a"));
+
+            expr =
+                (a) => a.Collection1
+                    .Any(
+                        c => c.Value1 != 3 && c.Collection1.Any(d => a.Value1 != 5));
+            exception = Assert.Throws<NotSupportedException>(() => Execute(CreateWhereQuery(expr)));
+            exception.Message.Should().Be(string.Format(NotSupportErrorMessageTemplate, "{document}{Collection1#null}.Where((({document}{Value1#null} != 3) AndAlso Any({document}{Collection1#null}.Where(({document}{Value1#a} != 5)))))", "a"));
+        }
+
+        private IEnumerable<BsonDocument> Execute<T>(IMongoQueryable<T> queryable)
+        {
+            var result = (AggregateQueryableExecutionModel<T>)queryable.GetExecutionModel();
+            return result.Stages;
+        }
+
+        private IMongoQueryable<TestObject> CreateWhereQuery(Expression<Func<TestObject, bool>> expression)
+        {
+            return CreateQuery().Where(expression);
+        }
+
+        private IMongoQueryable<TestObject> CreateQuery()
+        {
+            return _collection.AsQueryable();
+        }
+    }
+}


### PR DESCRIPTION
CSHARP-2460: Add throwing exception if LINQ expressions use unreachable query members.

This code affects a lot of user scenarios and I'm not sure that I've considered all potential issues which may be. 
Also, maybe we have to consider some restrictions for this logic like having this logic only for `Any` or `Where` LINQ methods.