### PR TITLE
CSHARP-2269: Fix Select query when there are Linq query members from different expression levels.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -26,6 +26,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __aggregate = new Feature("Aggregate", new SemanticVersion(2, 2, 0));
         private static readonly Feature __aggregateAddFields = new Feature("AggregateAddFields", new SemanticVersion(3, 4, 0));
         private static readonly Feature __aggregateAllowDiskUse = new Feature("AggregateAllowDiskUse", new SemanticVersion(2, 6, 0));
+        private static readonly Feature __aggregateArrayFilter = new Feature("AggregateArrayFilter", new SemanticVersion(3, 2, 0));
         private static readonly Feature __aggregateBucketStage = new Feature("AggregateBucketStage", new SemanticVersion(3, 3, 11));
         private static readonly Feature __aggregateComment = new Feature("AggregateComment", new SemanticVersion(3, 6, 0, "rc0"));
         private static readonly Feature __aggregateCountStage = new Feature("AggregateCountStage", new SemanticVersion(3, 3, 11));
@@ -86,6 +87,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the aggregate allow disk use feature.
         /// </summary>
         public static Feature AggregateAllowDiskUse => __aggregateAllowDiskUse;
+
+        /// <summary>
+        /// Gets the aggregate array filter feature.
+        /// </summary>
+        public static Feature AggregateArrayFilter => __aggregateArrayFilter;
 
         /// <summary>
         /// Gets the aggregate bucket stage feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -26,7 +26,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __aggregate = new Feature("Aggregate", new SemanticVersion(2, 2, 0));
         private static readonly Feature __aggregateAddFields = new Feature("AggregateAddFields", new SemanticVersion(3, 4, 0));
         private static readonly Feature __aggregateAllowDiskUse = new Feature("AggregateAllowDiskUse", new SemanticVersion(2, 6, 0));
-        private static readonly Feature __aggregateArrayFilter = new Feature("AggregateArrayFilter", new SemanticVersion(3, 2, 0));
+        private static readonly Feature __aggregateFilter = new Feature("AggregateFilter", new SemanticVersion(3, 2, 0));
         private static readonly Feature __aggregateBucketStage = new Feature("AggregateBucketStage", new SemanticVersion(3, 3, 11));
         private static readonly Feature __aggregateComment = new Feature("AggregateComment", new SemanticVersion(3, 6, 0, "rc0"));
         private static readonly Feature __aggregateCountStage = new Feature("AggregateCountStage", new SemanticVersion(3, 3, 11));
@@ -89,9 +89,9 @@ namespace MongoDB.Driver.Core.Misc
         public static Feature AggregateAllowDiskUse => __aggregateAllowDiskUse;
 
         /// <summary>
-        /// Gets the aggregate array filter feature.
+        /// Gets the aggregate filter feature.
         /// </summary>
-        public static Feature AggregateArrayFilter => __aggregateArrayFilter;
+        public static Feature AggregateFilter => __aggregateFilter;
 
         /// <summary>
         /// Gets the aggregate bucket stage feature.

--- a/src/MongoDB.Driver/Linq/Expressions/FieldExpression.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/FieldExpression.cs
@@ -20,7 +20,7 @@ using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Linq.Expressions
 {
-    internal sealed class FieldExpression : SerializationExpression, IFieldExpression, IExpressionMemberInfo
+    internal sealed class FieldExpression : SerializationExpression, IFieldExpression, IHasOutOfCurrentScopePrefix
     {
         private readonly Expression _document;
         private readonly string _fieldName;

--- a/src/MongoDB.Driver/Linq/Expressions/FieldExpression.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/FieldExpression.cs
@@ -20,7 +20,7 @@ using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Linq.Expressions
 {
-    internal sealed class FieldExpression : SerializationExpression, IFieldExpression
+    internal sealed class FieldExpression : SerializationExpression, IFieldExpression, IExpressionMemberInfo
     {
         private readonly Expression _document;
         private readonly string _fieldName;
@@ -42,12 +42,13 @@ namespace MongoDB.Driver.Linq.Expressions
         {
         }
 
-        public FieldExpression(Expression document, string fieldName, IBsonSerializer serializer, Expression original)
+        public FieldExpression(Expression document, string fieldName, IBsonSerializer serializer, Expression original, string outOfCurrentScopePrefix = null)
         {
             _document = document;
             _fieldName = Ensure.IsNotNull(fieldName, nameof(fieldName));
             _serializer = Ensure.IsNotNull(serializer, nameof(serializer));
             _original = original;
+            OutOfCurrentScopePrefix = outOfCurrentScopePrefix;
         }
 
         public Expression Document
@@ -59,6 +60,8 @@ namespace MongoDB.Driver.Linq.Expressions
         {
             get { return _fieldName; }
         }
+
+        public string OutOfCurrentScopePrefix { get; set; }
 
         public override ExtensionExpressionType ExtensionType
         {

--- a/src/MongoDB.Driver/Linq/Expressions/FieldExpression.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/FieldExpression.cs
@@ -26,6 +26,7 @@ namespace MongoDB.Driver.Linq.Expressions
         private readonly string _fieldName;
         private readonly Expression _original;
         private readonly IBsonSerializer _serializer;
+        private string _outOfCurrentScopePrefix;
 
         public FieldExpression(string fieldName, IBsonSerializer serializer)
             : this(null, fieldName, serializer, null)
@@ -48,7 +49,7 @@ namespace MongoDB.Driver.Linq.Expressions
             _fieldName = Ensure.IsNotNull(fieldName, nameof(fieldName));
             _serializer = Ensure.IsNotNull(serializer, nameof(serializer));
             _original = original;
-            OutOfCurrentScopePrefix = outOfCurrentScopePrefix;
+            _outOfCurrentScopePrefix = outOfCurrentScopePrefix;
         }
 
         public Expression Document
@@ -61,7 +62,11 @@ namespace MongoDB.Driver.Linq.Expressions
             get { return _fieldName; }
         }
 
-        public string OutOfCurrentScopePrefix { get; set; }
+        public string OutOfCurrentScopePrefix
+        {
+            get { return _outOfCurrentScopePrefix; }
+            set { _outOfCurrentScopePrefix = value; }
+        }
 
         public override ExtensionExpressionType ExtensionType
         {

--- a/src/MongoDB.Driver/Linq/Expressions/IExpressionMemberInfo.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/IExpressionMemberInfo.cs
@@ -15,7 +15,7 @@
 
 namespace MongoDB.Driver.Linq.Expressions
 {
-    internal interface IExpressionMemberInfo
+    internal interface IHasOutOfCurrentScopePrefix
     {
         string OutOfCurrentScopePrefix { get; set; }
     }

--- a/src/MongoDB.Driver/Linq/Expressions/IExpressionMemberInfo.cs
+++ b/src/MongoDB.Driver/Linq/Expressions/IExpressionMemberInfo.cs
@@ -1,0 +1,22 @@
+﻿/* Copyright 2019-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.Linq.Expressions
+{
+    internal interface IExpressionMemberInfo
+    {
+        string OutOfCurrentScopePrefix { get; set; }
+    }
+}

--- a/src/MongoDB.Driver/Linq/Processors/SerializationBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/SerializationBinder.cs
@@ -163,7 +163,9 @@ namespace MongoDB.Driver.Linq.Processors
 
                     var rawParameterExpression = (node.Expression as ParameterExpression);
                     if (_isOutOfCurrentScope && rawParameterExpression != null)
-                        SaveOutOfScopePrefix(newNode, rawParameterExpression.Name);
+                    {
+                        SetOutOfCurrentScopePrefixIfPossible(newNode, rawParameterExpression.Name);
+                    }
                 }
             }
 
@@ -411,9 +413,9 @@ namespace MongoDB.Driver.Linq.Processors
             return node;
         }
 
-        private void SaveOutOfScopePrefix(Expression expression, string value)
+        private void SetOutOfCurrentScopePrefixIfPossible(Expression expression, string value)
         {
-            var memberInfo = expression as IExpressionMemberInfo;
+            var memberInfo = expression as IHasOutOfCurrentScopePrefix;
             if (memberInfo != null)
             {
                 memberInfo.OutOfCurrentScopePrefix = value;

--- a/src/MongoDB.Driver/Linq/Translators/FieldNamePrefixer.cs
+++ b/src/MongoDB.Driver/Linq/Translators/FieldNamePrefixer.cs
@@ -53,7 +53,8 @@ namespace MongoDB.Driver.Linq.Translators
                 node.Document,
                 node.PrependFieldName(_prefix),
                 node.Serializer,
-                node.Original);
+                node.Original,
+                node.OutOfCurrentScopePrefix);
         }
 
         protected internal override Expression VisitPipeline(PipelineExpression node)

--- a/src/MongoDB.Driver/Linq/Translators/FieldNamePrefixer.cs
+++ b/src/MongoDB.Driver/Linq/Translators/FieldNamePrefixer.cs
@@ -49,9 +49,13 @@ namespace MongoDB.Driver.Linq.Translators
                     node.Original);
             }
 
+            var prefix = !string.IsNullOrWhiteSpace(node.OutOfCurrentScopePrefix)
+                ? node.OutOfCurrentScopePrefix
+                : _prefix;
+
             return new FieldExpression(
                 node.Document,
-                node.PrependFieldName(_prefix),
+                node.PrependFieldName(prefix),
                 node.Serializer,
                 node.Original,
                 node.OutOfCurrentScopePrefix);

--- a/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
@@ -237,7 +237,6 @@ namespace MongoDB.Driver.Tests.Linq
         {
             public bool B { get; set; }
             public int N { get; set; }
-
             public string D { get; set; }
 
             public E E { get; set; }

--- a/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
@@ -82,7 +82,8 @@ namespace MongoDB.Driver.Tests.Linq
                                         D = "Delilah"
                                     }
                             },
-                            N = 1
+                            N = 1,
+                            Y = new List<E> { new E { F = 101 }, new V { W = 102 } }
                         },
                         new C
                         {
@@ -93,7 +94,8 @@ namespace MongoDB.Driver.Tests.Linq
                                 H = 66,
                                 I = new [] { "insecure"}
                             },
-                            N = 2
+                            N = 2,
+                            Y = new List<E> { new E { F = 103 }, new V { W = 104 } }
                         }
                 },
                 Id = 10,
@@ -137,7 +139,8 @@ namespace MongoDB.Driver.Tests.Linq
                                 H = 444,
                                 I = new [] { "igloo" }
                             },
-                            N = 3
+                            N = 3,
+                            Y = new List<E> { new E { F = 105 }, new V { W = 106 } }
                         },
                         new C
                         {
@@ -235,6 +238,7 @@ namespace MongoDB.Driver.Tests.Linq
 
         public class C
         {
+            public bool B { get; set; }
             public int N { get; set; }
 
             public string D { get; set; }
@@ -244,6 +248,7 @@ namespace MongoDB.Driver.Tests.Linq
             public IEnumerable<C> S { get; set; }
 
             public IEnumerable<E> X { get; set; }
+            public IEnumerable<E> Y { get; set; }
         }
 
         public class E

--- a/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
@@ -82,8 +82,7 @@ namespace MongoDB.Driver.Tests.Linq
                                         D = "Delilah"
                                     }
                             },
-                            N = 1,
-                            Y = new List<E> { new E { F = 101 }, new V { W = 102 } }
+                            N = 1
                         },
                         new C
                         {
@@ -94,8 +93,7 @@ namespace MongoDB.Driver.Tests.Linq
                                 H = 66,
                                 I = new [] { "insecure"}
                             },
-                            N = 2,
-                            Y = new List<E> { new E { F = 103 }, new V { W = 104 } }
+                            N = 2
                         }
                 },
                 Id = 10,
@@ -139,8 +137,7 @@ namespace MongoDB.Driver.Tests.Linq
                                 H = 444,
                                 I = new [] { "igloo" }
                             },
-                            N = 3,
-                            Y = new List<E> { new E { F = 105 }, new V { W = 106 } }
+                            N = 3
                         },
                         new C
                         {
@@ -248,7 +245,6 @@ namespace MongoDB.Driver.Tests.Linq
             public IEnumerable<C> S { get; set; }
 
             public IEnumerable<E> X { get; set; }
-            public IEnumerable<E> Y { get; set; }
         }
 
         public class E

--- a/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
@@ -81,7 +81,8 @@ namespace MongoDB.Driver.Tests.Linq
                                     {
                                         D = "Delilah"
                                     }
-                            }
+                            },
+                            N = 1
                         },
                         new C
                         {
@@ -91,7 +92,8 @@ namespace MongoDB.Driver.Tests.Linq
                                 F = 55,
                                 H = 66,
                                 I = new [] { "insecure"}
-                            }
+                            },
+                            N = 2
                         }
                 },
                 Id = 10,
@@ -134,7 +136,8 @@ namespace MongoDB.Driver.Tests.Linq
                                 F = 333,
                                 H = 444,
                                 I = new [] { "igloo" }
-                            }
+                            },
+                            N = 3
                         },
                         new C
                         {
@@ -144,7 +147,8 @@ namespace MongoDB.Driver.Tests.Linq
                                 F = 555,
                                 H = 666,
                                 I = new [] { "icy" }
-                            }
+                            },
+                            N = 4
                         }
                 },
                 Id = 20,
@@ -231,6 +235,8 @@ namespace MongoDB.Driver.Tests.Linq
 
         public class C
         {
+            public int N { get; set; }
+
             public string D { get; set; }
 
             public E E { get; set; }

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
@@ -543,7 +543,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert(
                 x => x.C == new C { D = "Dexter" },
                 0,
-                "{C: {D: 'Dexter', E: null, S: null, X: null}}");
+                "{ C : { B : false, N : 0, D : 'Dexter', E : null, S : null, X : null } }");
         }
 
         [Fact]
@@ -552,7 +552,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert(
                 x => x.C.Equals(new C { D = "Dexter" }),
                 0,
-                "{C: {D: 'Dexter', E: null, S: null, X: null}}");
+                "{ C : { B : false, N : 0, D : 'Dexter', E : null, S : null, X : null } }");
         }
 
         [Fact]
@@ -561,7 +561,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert(
                 x => x.C != new C { D = "Dexter" },
                 2,
-                "{C: {$ne: {D: 'Dexter', E: null, S: null, X: null}}}");
+                "{ C : { $ne : { B : false, N : 0, D : 'Dexter', E : null, S : null, X : null } } }");
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateValueConversionTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateValueConversionTests.cs
@@ -46,7 +46,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert(
                 x => x.C == objectToConvert,
                 0,
-                "{ C : { D : 'Dexter', E : null, S : null, X : null } }");
+                "{ C : { B : false, N : 0, D : 'Dexter', E : null, S : null, X : null } }");
         }
 
         public void Assert(Expression<Func<Root, bool>> filter, int expectedCount, string expectedFilter)


### PR DESCRIPTION
For now, I didn't check the possible solution via `Original` field in `FieldExpression`. I will do it tomorrow morning maybe with a small refactoring.

The current solution covers the only case (with `Select` method) which has been described in the ticket.
But I guess similar behavior should be added to some other `Translate` methods, for example to the `TranslateField`. I made a draft commit with these changes (with a question which is currently not clear for me): https://github.com/DmitryLukyanov/mongo-csharp-driver/commit/c24d318c78b3ff10f4e205224491846cdbac49a7. 