### PR TITLE
CSHARP-2557 Change in behaviour of parsing nested .Any predicates

### DIFF
--- a/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
@@ -16,7 +16,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace MongoDB.Driver.Tests.Linq
@@ -101,7 +101,8 @@ namespace MongoDB.Driver.Tests.Linq
                                     {
                                         D = "Delilah"
                                     }
-                            }
+                            },
+                            Ids = new [] { new ObjectId("111111111111111111111111") }
                         },
                         new C
                         {
@@ -251,6 +252,8 @@ namespace MongoDB.Driver.Tests.Linq
 
         public class C
         {
+            public IEnumerable<ObjectId> Ids { get; set; }
+
             public string D { get; set; }
 
             public E E { get; set; }

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
@@ -121,6 +121,56 @@ namespace MongoDB.Driver.Tests.Linq.Translators
         }
 
         [Fact]
+        public void Any_with_a_predicate_on_document_itself()
+        {
+            Assert(
+                x => x.G.Any(g => g != null),
+                2,
+                "{ 'G' : { '$elemMatch' : { '$ne' : null } } }");
+
+            Assert(
+                x => x.G.Any(g => null != g),
+                2,
+                "{ 'G' : { '$elemMatch' : { '$ne' : null } } }");
+
+            Assert(
+                x => x.G.Any(g => g.E.I.Any(i => i == "insecure")),
+                1,
+                "{ \"G.E.I\" : { '$elemMatch' : { '$eq': 'insecure' } } }");
+        }
+
+        [Fact]
+        public void Any_with_a_predicate_on_document_itself_and_objectId()
+        {
+            Assert(
+                x => x.G.Any(g => g.Ids.Any(i => i == ObjectId.Parse("111111111111111111111111"))),
+                1,
+                "{ 'G.Ids' : { '$elemMatch' : { '$eq' : ObjectId('111111111111111111111111') } } }");
+        }
+
+        [Fact]
+        public void Any_with_a_predicate_on_documents_itself_and_ClassEquals()
+        {
+            var c1 = new C()
+            {
+                D = "Dolphin",
+                E = new E()
+                {
+                    F = 55,
+                    H = 66,
+                    I = new List<string>()
+                    {
+                        "insecure"
+                    }
+                }
+            };
+            Assert(
+                x => x.G.Any(g => g == c1),
+                1,
+                "{ \"G\" : { \"$elemMatch\" : { \"Ids\" : null, \"D\" : \"Dolphin\", \"E\" : { \"F\" : 55, \"H\" : 66, \"I\" : [\"insecure\"] }, \"S\" : null, \"X\" : null } } }");
+        }
+
+        [Fact]
         public void Any_with_a_gte_predicate_on_documents()
         {
             Assert(
@@ -585,7 +635,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert(
                 x => x.C == new C { D = "Dexter" },
                 0,
-                "{C: {D: 'Dexter', E: null, S: null, X: null}}");
+                "{ C : { Ids : null, D : 'Dexter', E : null, S : null, X : null } }");
         }
 
         [Fact]
@@ -594,7 +644,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert(
                 x => x.C.Equals(new C { D = "Dexter" }),
                 0,
-                "{C: {D: 'Dexter', E: null, S: null, X: null}}");
+                "{ C : { Ids : null, D : 'Dexter', E : null, S : null, X : null } }");
         }
 
         [Fact]
@@ -603,7 +653,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert(
                 x => x.C != new C { D = "Dexter" },
                 2,
-                "{C: {$ne: {D: 'Dexter', E: null, S: null, X: null}}}");
+                "{ C : { $ne : { Ids : null, D : 'Dexter', E : null, S : null, X : null } } }");
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateValueConversionTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateValueConversionTests.cs
@@ -46,7 +46,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert(
                 x => x.C == objectToConvert,
                 0,
-                "{ C : { D : 'Dexter', E : null, S : null, X : null } }");
+                "{ C : { Ids : null, D : 'Dexter', E : null, S : null, X : null } }");
         }
 
         public void Assert(Expression<Func<Root, bool>> filter, int expectedCount, string expectedFilter)


### PR DESCRIPTION
*NOTE*: I've changed the solution which I described in the dev chat (about just adding an additional condition to `CanAnyBeRenderedWithoutElemMatch` method) since a similar fix logic already exists (The first commit in this ticket contains logic which I meant originally).
But, already existing logic affects only fields(which calls `Any`) which were not inherited from: `IBsonDocumentSerializer`.

I've added a rule, in case if the field is inherited from `IBsonDocumentSerializer`, we will additionally look at a predicate. if the predicate is `BinaryExpression` and the left branch is `DocumentExpression`, I assume that this left branch is a `document` itself. 

If we generate `$elemMatch` query for this expression without the new rule (as it was before), we will have `gaps` in query structure and the query will look like: 

    { G : { "$elemMatch" : { "" : { "$ne" : null } } } }.

With the new rule we will have correct query:

    "{ 'G' : { '$elemMatch' : { '$ne' : null } } }"); 

*NOTE_2*: `BinaryExpression` is not only for `comparisons` operands. So, this condition: 

    `if (node is BinaryExpression binaryExpression)` 

will also return true, for queries with `and` or `or` like:

    Any(p=> p.Name == "test" && p.Age > 10)

but the second part of the new rule will return `false` since no one from the expression parts is `DocumentExpression`.

*NOTE_3*: There are a number of tests which I commented out in these commits which have wrong results. But they are legacy bugs and is not connected with previous tickets. @jyemin, @rstam, should I create a new ticket about them?
