### PR TITLE
CSHARP-2408: Support index all paths.

### DIFF
--- a/Docs/reference/content/reference/driver/admin.md
+++ b/Docs/reference/content/reference/driver/admin.md
@@ -189,6 +189,47 @@ collection.Indexes.CreateOne("{ x : 1 }", options);
 await collection.Indexes.CreateOneAsync("{ x : 1 }", options);
 ```
 
+Also, there is a generic [`CreateIndexOptions<TDocument>`]({{< apiref "T_MongoDB_Driver_CreateIndexOptions_1" >}}) which extends the non-generic version and provides a number of additional options available when creating an index. For example, to create a `wildcard projection` index on "name" and "description.text", do the following:
+
+Given the following classes:
+
+```csharp
+public class Description
+{
+    [BsonElement("text")]
+    public string Text { get; set; }
+}
+
+public class Widget
+{
+    public ObjectId Id { get; set; }
+
+    [BsonElement("name")]
+    public int Name { get; set; }
+
+    [BsonElement("description")]
+    public Description Description { get; set; }
+}
+```
+
+The wildcard projection value can be implicitly convertible from both a JSON string as well as a [`BsonDocument`]({{< apiref "T_MongoDB_Bson_BsonDocument" >}}).
+
+```csharp
+var options = new CreateIndexOptions<Widget>();
+
+options.WildcardProjection = "{ 'name' : 1, 'description.text' : 1 }";
+
+//or
+
+options.WildcardProjection = new BsonDocument { { "name", 1 }, { "description.text", 1 } };
+```
+
+We can achieve the same result with using a `projection` builder:
+
+```csharp
+options.WildcardProjection = Builders<Widget>.Projection.Include(x => x.Name).Include(x => x.Description.Text);
+```
+
 ### Dropping an index
 
 To drop a single index use the [`DropOne`]({{< apiref "M_MongoDB_Driver_IMongoIndexManager_1_DropOne" >}}) or [`DropOneAsync`]({{< apiref "M_MongoDB_Driver_IMongoIndexManager_1_DropOneAsync" >}}) methods.

--- a/Docs/reference/content/reference/driver/definitions.md
+++ b/Docs/reference/content/reference/driver/definitions.md
@@ -443,3 +443,29 @@ var keys = builder.Ascending("X").Descending("Y");
 
 var keys = builder.Ascending("x").Descending("y");
 ```
+
+Also, the builder provides API methods to build a wildcard index. There are two ways to do it: `All field paths` and `A single field path`.
+
+For example, to build up the `All field paths` key `{ "$**": 1 }` or `A single field path` key `{ "x.$**": 1 }`, do the following:
+
+```csharp
+var builder = Builders<BsonDocument>.IndexKeys;
+
+// All field paths
+var keys = builder.Wildcard();
+
+// A single field path
+var keys = builder.Wildcard("x");
+```
+
+We can achieve the same result in the typed variant:
+
+```csharp
+var builder = Builders<Widget>.IndexKeys;
+
+// All field paths
+var keys = builder.Wildcard();
+
+// A single field path
+var keys = builder.Wildcard(x => x.X);
+```

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -72,6 +72,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __transactions = new Feature("Transactions", new SemanticVersion(4, 0, 0));
         private static readonly Feature __userManagementCommands = new Feature("UserManagementCommands", new SemanticVersion(2, 6, 0));
         private static readonly Feature __views = new Feature("Views", new SemanticVersion(3, 3, 11));
+        private static readonly Feature __wildcardIndexes = new Feature("WildcardIndexes", new SemanticVersion(4, 1, 6));
         private static readonly Feature __writeCommands = new Feature("WriteCommands", new SemanticVersion(2, 6, 0));
 
         /// <summary>
@@ -323,6 +324,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the write commands feature.
         /// </summary>
         public static Feature WriteCommands => __writeCommands;
+
+        /// <summary>
+        /// Gets the wildcard indexes feature.
+        /// </summary>
+        public static Feature WildcardIndexes => __wildcardIndexes;
         #endregion
 
         private readonly string _name;

--- a/src/MongoDB.Driver.Core/Core/Operations/CreateIndexRequest.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/CreateIndexRequest.cs
@@ -14,8 +14,6 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
 
@@ -47,6 +45,7 @@ namespace MongoDB.Driver.Core.Operations
         private bool? _unique;
         private int? _version;
         private BsonDocument _weights;
+        private BsonDocument _wildcardProjection;
 
         // constructors
         /// <summary>
@@ -295,6 +294,18 @@ namespace MongoDB.Driver.Core.Operations
             set { _weights = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the wildcard projection.
+        /// </summary>
+        /// <value>
+        /// The wildcardProjection for indexes.
+        /// </value>
+        public BsonDocument WildcardProjection
+        {
+            get { return _wildcardProjection;  }
+            set { _wildcardProjection = value; }
+        }
+
         // publuc methods
         /// <summary>
         /// Gets the name of the index.
@@ -344,7 +355,8 @@ namespace MongoDB.Driver.Core.Operations
                 { "textIndexVersion", () => _textIndexVersion.Value, _textIndexVersion.HasValue },
                 { "unique", () => _unique.Value, _unique.HasValue },
                 { "v", () => _version.Value, _version.HasValue },
-                { "weights", () => _weights, _weights != null }
+                { "weights", () => _weights, _weights != null },
+                { "wildcardProjection", _wildcardProjection, _wildcardProjection != null }
             };
 
             if (_additionalOptions != null)

--- a/src/MongoDB.Driver.Legacy/Builders/IndexKeysBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/IndexKeysBuilder.cs
@@ -120,6 +120,16 @@ namespace MongoDB.Driver.Builders
         {
             return new IndexKeysBuilder().TextAll();
         }
+
+        /// <summary>
+        /// Sets a wildcard key to the index. The method doesn't expect to specify a wildcard key explicitly.
+        /// </summary>
+        /// <param name="name">The wildcard key name. If the wildcard name is empty, the generated key will be `All field paths`, otherwise `A single field path`.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public static IndexKeysBuilder Wildcard(string name = null)
+        {
+            return new IndexKeysBuilder().Wildcard(name);
+        }
     }
 
     /// <summary>
@@ -261,6 +271,28 @@ namespace MongoDB.Driver.Builders
             return _document;
         }
 
+        /// <summary>
+        /// Sets a wildcard key to the index. The method doesn't expect to specify a wildcard key explicitly.
+        /// </summary>
+        /// <param name="name">The wildcard key name. If the wildcard name is empty, the generated key will be `All field paths`, otherwise `A single field path`.</param>
+        /// <returns>The builder (so method calls can be chained).</returns>
+        public IndexKeysBuilder Wildcard(string name = null)
+        {
+            var wildcard = name;
+            if (wildcard == null)
+            {
+                wildcard = "$**";
+            }
+            else
+            {
+                wildcard += ".$**";
+            }
+
+            _document.Add(wildcard, 1);
+
+            return this;
+        }
+
         // nested class
         new internal class Serializer : SerializerBase<IndexKeysBuilder>
         {
@@ -398,6 +430,17 @@ namespace MongoDB.Driver.Builders
             return new IndexKeysBuilder<TDocument>().TextAll();
         }
 
+        /// <summary>
+        /// Sets a wildcard key to the index.
+        /// </summary>
+        /// <param name="memberExpression">The member expression representing the wildcard key name. If the wildcard name is empty, the generated key will be `All field paths`, otherwise `A single field path`.</param>
+        /// <returns>
+        /// The builder (so method calls can be chained).
+        /// </returns>
+        public static IndexKeysBuilder<TDocument> Wildcard(Expression<Func<TDocument, object>> memberExpression = null)
+        {
+            return new IndexKeysBuilder<TDocument>().Wildcard(memberExpression);
+        }
     }
 
     /// <summary>
@@ -564,6 +607,20 @@ namespace MongoDB.Driver.Builders
         public override BsonDocument ToBsonDocument()
         {
             return _indexKeysBuilder.ToBsonDocument();
+        }
+
+        /// <summary>
+        /// Sets a wildcard key to the index.
+        /// </summary>
+        /// <param name="memberExpression">The member expression representing the wildcard key name. If the wildcard name is empty, the generated key will be `All field paths`, otherwise `A single field path`.</param>
+        /// <returns>
+        /// The builder (so method calls can be chained).
+        /// </returns>
+        public IndexKeysBuilder<TDocument> Wildcard(Expression<Func<TDocument, object>> memberExpression = null)
+        {
+            var name = memberExpression != null ? GetElementName(memberExpression) : null;
+            _indexKeysBuilder = _indexKeysBuilder.Wildcard(name);
+            return this;
         }
 
         // private methods

--- a/src/MongoDB.Driver.Legacy/Builders/IndexOptionsBuilder.cs
+++ b/src/MongoDB.Driver.Legacy/Builders/IndexOptionsBuilder.cs
@@ -181,6 +181,19 @@ namespace MongoDB.Driver.Builders
         {
             return new IndexOptionsBuilder().SetWeight(name, value);
         }
+
+        /// <summary>
+        /// Sets the wildcardProjection for the index.
+        /// </summary>
+        /// <param name="name">The field name.</param>
+        /// <param name="included">The flag determines whether the field should be included or excluded from wildcard projecting.</param>
+        /// <returns>
+        /// The builder (so method calls can be chained).
+        /// </returns>
+        public static IndexOptionsBuilder SetWildcardProjection(string name, bool included)
+        {
+            return new IndexOptionsBuilder().SetWildcardProjection(name, included);
+        }
     }
 
     /// <summary>
@@ -370,6 +383,26 @@ namespace MongoDB.Driver.Builders
             return this;
         }
 
+        ///  <summary>
+        ///  Sets the wildcardProjection for the index.
+        ///  </summary>
+        ///  <param name="name">The field name.</param>
+        ///  <param name="included">The flag determines whether the field should be included or excluded from wildcard projecting.</param>
+        ///  <returns>
+        /// The builder (so method calls can be chained).
+        ///  </returns>
+        public IndexOptionsBuilder SetWildcardProjection(string name, bool included)
+        {
+            if (!_document.TryGetValue("wildcardProjection", out var wildcardProjection))
+            {
+                wildcardProjection = new BsonDocument();
+                _document.Add("wildcardProjection", wildcardProjection);
+            }
+
+            wildcardProjection[name] = included ? 1 : 0;
+            return this;
+        }
+
         /// <summary>
         /// Returns the result of the builder as a BsonDocument.
         /// </summary>
@@ -550,6 +583,20 @@ namespace MongoDB.Driver.Builders
         public static IndexOptionsBuilder<TDocument> SetWeight<TMember>(Expression<Func<TDocument, TMember>> memberExpression, int value)
         {
             return new IndexOptionsBuilder<TDocument>().SetWeight(memberExpression, value);
+        }
+
+        /// <summary>
+        /// Sets the wildcardProjection for the index.
+        /// </summary>
+        /// <typeparam name="TMember">The type of the member.</typeparam>
+        /// <param name="memberExpression">The member expression representing the wildcard projection field name.</param>
+        /// <param name="included">The flag determines whether the field should be included or excluded from wildcard projecting.</param>
+        /// <returns>
+        /// The builder (so method calls can be chained).
+        /// </returns>
+        public static IndexOptionsBuilder<TDocument> SetWildcardProjection<TMember>(Expression<Func<TDocument, TMember>> memberExpression, bool included)
+        {
+            return new IndexOptionsBuilder<TDocument>().SetWildcardProjection(memberExpression, included);
         }
     }
 
@@ -738,6 +785,22 @@ namespace MongoDB.Driver.Builders
         {
             var serializationInfo = _serializationInfoHelper.GetSerializationInfo(memberExpression);
             _indexOptionsBuilder = _indexOptionsBuilder.SetWeight(serializationInfo.ElementName, value);
+            return this;
+        }
+
+        ///  <summary>
+        ///  Sets the wildcardProjection for the index.
+        ///  </summary>
+        ///  <typeparam name="TMember">The type of the member.</typeparam>
+        ///  <param name="memberExpression">The member expression representing the wildcard projection field name.</param>
+        ///  <param name="included">The flag determines whether the field should be included or excluded from wildcard projecting.</param>
+        ///  <returns>
+        /// The builder (so method calls can be chained).
+        ///  </returns>
+        public IndexOptionsBuilder<TDocument> SetWildcardProjection<TMember>(Expression<Func<TDocument, TMember>> memberExpression, bool included)
+        {
+            var serializationInfo = _serializationInfoHelper.GetSerializationInfo(memberExpression);
+            _indexOptionsBuilder = _indexOptionsBuilder.SetWildcardProjection(serializationInfo.ElementName, included);
             return this;
         }
 

--- a/src/MongoDB.Driver/CreateIndexOptions.cs
+++ b/src/MongoDB.Driver/CreateIndexOptions.cs
@@ -242,6 +242,7 @@ namespace MongoDB.Driver
 
         // private fields
         private FilterDefinition<TDocument> _partialFilterExpression;
+        private ProjectionDefinition<TDocument> _wildcardProjection;
 
         // public properties
         /// <summary>
@@ -251,6 +252,15 @@ namespace MongoDB.Driver
         {
             get { return _partialFilterExpression; }
             set { _partialFilterExpression = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the wildcard projection.
+        /// </summary>
+        public ProjectionDefinition<TDocument> WildcardProjection
+        {
+            get { return _wildcardProjection; }
+            set { _wildcardProjection = value; }
         }
     }
 }

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -26,7 +26,6 @@ using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Operations;
 using MongoDB.Driver.Core.WireProtocol.Messages.Encoders;
-using MongoDB.Driver.Linq;
 
 namespace MongoDB.Driver
 {
@@ -1382,6 +1381,7 @@ namespace MongoDB.Driver
                     var options = m.Options ?? new CreateIndexOptions<TDocument>();
                     var keysDocument = m.Keys.Render(_collection._documentSerializer, _collection._settings.SerializerRegistry);
                     var renderedPartialFilterExpression = options.PartialFilterExpression == null ? null : options.PartialFilterExpression.Render(_collection._documentSerializer, _collection._settings.SerializerRegistry);
+                    var renderedWildcardProjection = options.WildcardProjection?.Render(_collection._documentSerializer, _collection._settings.SerializerRegistry);
 
                     return new CreateIndexRequest(keysDocument)
                     {
@@ -1402,7 +1402,8 @@ namespace MongoDB.Driver
                         TextIndexVersion = options.TextIndexVersion,
                         Unique = options.Unique,
                         Version = options.Version,
-                        Weights = options.Weights
+                        Weights = options.Weights,
+                        WildcardProjection = renderedWildcardProjection
                     };
                 });
             }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/IndexNameHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/IndexNameHelperTests.cs
@@ -15,6 +15,7 @@
 
 using FluentAssertions;
 using MongoDB.Bson;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
 using Xunit;
 
 namespace MongoDB.Driver.Core.Operations
@@ -47,6 +48,19 @@ namespace MongoDB.Driver.Core.Operations
         {
             var keys = new[] { "a", "b", "c c" };
             var expectedResult = "a_1_b_1_c_c_1";
+
+            var result = IndexNameHelper.GetIndexName(keys);
+
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
+        [ParameterAttributeData]
+        public void GetIndexName_with_wildcard_keys_should_return_expected_result(
+            [Values("$**", "a.$**")] string key)
+        {
+            var keys = new[] { key };
+            var expectedResult = key + "_1";
 
             var result = IndexNameHelper.GetIndexName(keys);
 

--- a/tests/MongoDB.Driver.Legacy.Tests/Builders/IndexKeysBuilderTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/Builders/IndexKeysBuilderTests.cs
@@ -13,13 +13,12 @@
 * limitations under the License.
 */
 
-using System;
 using System.Linq;
+using FluentAssertions;
 using MongoDB.Bson;
-using MongoDB.Bson.TestHelpers.XunitExtensions;
-using MongoDB.Driver;
 using MongoDB.Driver.Builders;
 using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using Xunit;
 
@@ -36,6 +35,42 @@ namespace MongoDB.Driver.Tests.Builders
             _server = LegacyTestConfiguration.Server;
             _database = LegacyTestConfiguration.Database;
             _primary = _server.Primary;
+        }
+
+        [SkippableFact]
+        public void CreateIndex_with_wildcard_index_should_create_expected_index()
+        {
+            RequireServer.Check().Supports(Feature.WildcardIndexes);
+            var collection = _database.GetCollection<BsonDocument>("test_wildcard_index");
+            collection.Drop();
+
+            collection.CreateIndex(
+                IndexKeys.Wildcard("a"),
+                IndexOptions
+                    .SetName("custom"));
+            var indexes = collection.GetIndexes();
+            var index = indexes.RawDocuments.Single(i => i["name"].AsString == "custom");
+
+            index["key"]["a.$**"].AsInt32.Should().Be(1);
+        }
+
+        [SkippableFact]
+        public void CreateIndex_with_wildcardProjection_should_create_expected_index()
+        {
+            RequireServer.Check().Supports(Feature.WildcardIndexes);
+            var collection = _database.GetCollection<BsonDocument>("test_wildcard_index");
+            collection.Drop();
+
+            collection.CreateIndex(
+                IndexKeys.Wildcard(), // wildcardProjection can be only with '$**'
+                IndexOptions
+                    .SetWildcardProjection("_id", true)
+                    .SetName("custom"));
+            var indexes = collection.GetIndexes();
+            var index = indexes.RawDocuments.Single(i => i["name"].AsString == "custom");
+
+            index["key"]["$**"].AsInt32.Should().Be(1);
+            index["wildcardProjection"].Should().Be(BsonDocument.Parse("{ _id : 1 }"));
         }
 
         [Fact]
@@ -218,6 +253,18 @@ namespace MongoDB.Driver.Tests.Builders
             Assert.Equal("idioma", index["language_override"].AsString);
             Assert.Equal("spanish", index["default_language"].AsString);
             Assert.Equal(1, index["key"]["c"].AsInt32);
+        }
+
+        [Fact]
+        public void Wildcard_should_return_expected_result()
+        {
+            var keys = IndexKeys.Wildcard();
+            BsonDocument expected = BsonDocument.Parse("{ \"$**\" : 1 }");
+            keys.ToBsonDocument().Should().Be(expected);
+
+            keys = IndexKeys.Wildcard("b");
+            expected = BsonDocument.Parse("{ \"b.$**\" : 1 }");
+            keys.ToBsonDocument().Should().Be(expected);
         }
     }
 }

--- a/tests/MongoDB.Driver.Legacy.Tests/Builders/IndexKeysBuilderTypedTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/Builders/IndexKeysBuilderTypedTests.cs
@@ -13,15 +13,14 @@
 * limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using MongoDB.Bson.TestHelpers.XunitExtensions;
-using MongoDB.Driver;
 using MongoDB.Driver.Builders;
 using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using Xunit;
 
@@ -56,6 +55,41 @@ namespace MongoDB.Driver.Tests.Builders
 
             [BsonElement("e")]
             public List<string> E { get; set; }
+
+            [BsonElement("_id")]
+            public int Id { get; set; }
+        }
+
+        [SkippableFact]
+        public void CreateIndex_with_wildcard_index_should_create_expected_index()
+        {
+            RequireServer.Check().Supports(Feature.WildcardIndexes);
+            var collection = _database.GetCollection<Test>("test_wildcard_index");
+            collection.Drop();
+            collection.CreateIndex(
+                IndexKeys<Test>.Wildcard(c => c.A),
+                IndexOptions.SetName("custom"));
+            var indexes = collection.GetIndexes();
+            var index = indexes.RawDocuments.Single(i => i["name"].AsString == "custom");
+            index["key"]["a.$**"].AsInt32.Should().Be(1);
+        }
+
+        [SkippableFact]
+        public void CreateIndex_with_wildcardProjection_should_create_expected_index()
+        {
+            RequireServer.Check().Supports(Feature.WildcardIndexes);
+            var collection = _database.GetCollection<Test>("test_wildcard_index");
+            collection.Drop();
+            collection.CreateIndex(
+                IndexKeys<Test>.Wildcard(),
+                IndexOptions<Test>
+                    .SetName("custom")
+                    .SetWildcardProjection(c => c.B, true)
+                    .SetWildcardProjection(c => c.Id, false));
+            var indexes = collection.GetIndexes();
+            var index = indexes.RawDocuments.Single(i => i["name"].AsString == "custom");
+            index["key"]["$**"].AsInt32.Should().Be(1);
+            index["wildcardProjection"].ToBsonDocument().Should().Be(BsonDocument.Parse("{ b : 1, _id : 0 }"));
         }
 
         [Fact]
@@ -269,6 +303,18 @@ namespace MongoDB.Driver.Tests.Builders
             Assert.Equal("idioma", index["language_override"].AsString);
             Assert.Equal("spanish", index["default_language"].AsString);
             Assert.Equal(1, index["key"]["c"].AsInt32);
+        }
+
+        [Fact]
+        public void Wildcard_index_should_return_expected_result()
+        {
+            var keys = IndexKeys<Test>.Wildcard();
+            BsonDocument expected = BsonDocument.Parse("{ \"$**\" : 1 }");
+            keys.ToBsonDocument().Should().Be(expected);
+
+            keys = IndexKeys<Test>.Wildcard(x => x.A);
+            expected = BsonDocument.Parse("{ \"a.$**\" : 1 }");
+            keys.ToBsonDocument().Should().Be(expected);
         }
     }
 }

--- a/tests/MongoDB.Driver.Legacy.Tests/Builders/IndexOptionsBuilderTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/Builders/IndexOptionsBuilderTests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Builders;
 using Xunit;
@@ -164,6 +165,18 @@ namespace MongoDB.Driver.Tests.Builders
             var options = IndexOptions.SetWeight("a", 2).SetWeight("b", 10);
             string expected = "{ \"weights\" : { \"a\" : 2, \"b\" : 10 } }";
             Assert.Equal(expected, options.ToJson());
+        }
+
+        [Fact]
+        public void WildcardProjection_should_return_expected_result()
+        {
+            var options = IndexOptions.SetWildcardProjection("a", true);
+            BsonDocument expected = BsonDocument.Parse("{ \"wildcardProjection\" : { \"a\" : 1 } }");
+            options.ToBsonDocument().Should().Be(expected);
+
+            options = IndexOptions.SetWildcardProjection("a.b", true).SetWildcardProjection("_id", false);
+            expected = BsonDocument.Parse("{ \"wildcardProjection\" : { \"a.b\" : 1, \"_id\" :  0} }");
+            options.ToBsonDocument().Should().Be(expected);
         }
     }
 }

--- a/tests/MongoDB.Driver.Legacy.Tests/Builders/IndexOptionsBuilderTypedTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/Builders/IndexOptionsBuilderTypedTests.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Builders;
 using Xunit;
@@ -22,12 +23,17 @@ namespace MongoDB.Driver.Tests.Builders
 {
     public class IndexOptionsBuilderTypedTests
     {
-
         public class TestClass
         {
             public int _id;
             public string textfield;
             public string idioma;
+            public Details details = new Details();
+        }
+
+        public class Details
+        {
+            public string text;
         }
 
         [Fact]
@@ -172,6 +178,20 @@ namespace MongoDB.Driver.Tests.Builders
             var options = IndexOptions<TestClass>.SetWeight(x => x.textfield, 2).SetWeight(x => x.idioma, 10);
             string expected = "{ \"weights\" : { \"textfield\" : 2, \"idioma\" : 10 } }";
             Assert.Equal(expected, options.ToJson());
+        }
+
+        [Fact]
+        public void WildcardProjection_should_return_expected_result()
+        {
+            var options = IndexOptions<TestClass>.SetWildcardProjection(x => x.textfield, true);
+            BsonDocument expected = BsonDocument.Parse("{ \"wildcardProjection\" : { \"textfield\" : 1 } }");
+            options.ToBsonDocument().Should().Be(expected);
+
+            options = IndexOptions<TestClass>
+                .SetWildcardProjection(x => x._id, false)
+                .SetWildcardProjection(x => x.details.text, true);
+            expected = BsonDocument.Parse("{ \"wildcardProjection\" : { \"_id\" : 0, \"details.text\" : 1 } }");
+            options.ToBsonDocument().Should().Be(expected);
         }
     }
 }

--- a/tests/MongoDB.Driver.Tests/IndexKeysDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/IndexKeysDefinitionBuilderTests.cs
@@ -184,11 +184,33 @@ namespace MongoDB.Driver.Tests
             Assert(subject.Text("$**"), "{'$**': 'text'}");
         }
 
+        [Fact]
+        public void Wildcard_should_return_expected_result()
+        {
+            var subject = CreateSubject<BsonDocument>();
+
+            Assert(subject.Wildcard("a"), "{ 'a.$**' : 1 }");
+            Assert(subject.Wildcard(), "{ '$**' : 1 }");
+        }
+
+        [Fact]
+        public void Wildcard_typed_should_return_expected_result()
+        {
+            var subject = CreateSubject<Person>();
+
+            Assert(subject.Wildcard(person => person.FirstName), "{ 'fn.$**' : 1 }"); // with BsonElement attribute
+            Assert(subject.Wildcard(person => person.Info), "{ 'Info.$**' : 1 }");
+            Assert(subject.Wildcard(person => person.Age), "{ 'Age.$**' : 1 }");
+            Assert(subject.Wildcard(person => person.Job), "{ 'Job.$**' : 1 }");
+            Assert(subject.Wildcard(person => person.Interviews), "{ 'Interviews.$**' : 1 }");
+        }
+
+
         private void Assert<TDocument>(IndexKeysDefinition<TDocument> keys, string expectedJson)
         {
-            var renderedSort = Render<TDocument>(keys);
+            var rendered = Render(keys);
 
-            renderedSort.Should().Be(expectedJson);
+            rendered.Should().Be(expectedJson);
         }
 
         private BsonDocument Render<TDocument>(IndexKeysDefinition<TDocument> keys)
@@ -209,6 +231,19 @@ namespace MongoDB.Driver.Tests
 
             [BsonElement("ln")]
             public string LastName { get; set; }
+
+            public string Info { get; set; }
+
+            public int Age { get; set; }
+
+            public Job Job { get; set; }
+
+            public Job[] Interviews { get; set; }
+        }
+
+        public class Job
+        {
+            public string Title { get; set; }
         }
     }
 }


### PR DESCRIPTION
Docs: https://docs-mongodbcom-staging.corp.mongodb.com/rk-mongo/DOCS-12275/core/index-wildcard.html
Docs2: https://docs.google.com/document/d/1sFHgi4ebGHkoUSLyI0mfnKAgRH-9mUFQ8rpdRx36mGU/edit#heading=h.r6xmnuohpdyj
Docs3: https://docs-mongodbcom-staging.corp.mongodb.com/rk-mongo/DOCS-12275/reference/index-wildcard-limitations.html#wildcard-index-limitations-create

Evergreen: https://evergreen.mongodb.com/version/5cc2f1b32a60ed432f5f3b04

NOTE: I also updated `legacy` code. In case if it's not needed I will remove it.