### PR TITLE
CSHARP-2528: Add support for majority read concern level to Aggregation $out.

### DIFF
--- a/src/MongoDB.Driver.Legacy/MongoCollection.cs
+++ b/src/MongoDB.Driver.Legacy/MongoCollection.cs
@@ -153,6 +153,7 @@ namespace MongoDB.Driver
                     BypassDocumentValidation = args.BypassDocumentValidation,
                     Collation = args.Collation,
                     MaxTime = args.MaxTime,
+                    ReadConcern = _settings.ReadConcern,
                     WriteConcern = _settings.WriteConcern
                 };
                 ExecuteWriteOperation(session, aggregateOperation);

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -742,6 +742,7 @@ namespace MongoDB.Driver
                 Comment = options.Comment,
                 Hint = options.Hint,
                 MaxTime = options.MaxTime,
+                ReadConcern = _settings.ReadConcern,
                 WriteConcern = _settings.WriteConcern
             };
         }

--- a/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
@@ -143,6 +143,7 @@ namespace MongoDB.Driver
             [Values(false, true)] bool async)
         {
             var writeConcern = new WriteConcern(1);
+            var readConcern = new ReadConcern(ReadConcernLevel.Majority);
             var subject = CreateSubject<BsonDocument>().WithWriteConcern(writeConcern);
             var session = CreateSession(usingSession);
             var pipeline = new EmptyPipelineDefinition<BsonDocument>()
@@ -199,6 +200,7 @@ namespace MongoDB.Driver
             aggregateOperation.Hint.Should().Be(options.Hint);
             aggregateOperation.MaxTime.Should().Be(options.MaxTime);
             aggregateOperation.Pipeline.Should().Equal(renderedPipeline.Documents);
+            aggregateOperation.ReadConcern.Should().Be(readConcern);
             aggregateOperation.WriteConcern.Should().BeSameAs(writeConcern);
 
             var mockCursor = new Mock<IAsyncCursor<BsonDocument>>();

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/ChangeStreamTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/ChangeStreamTestRunner.cs
@@ -236,15 +236,11 @@ namespace MongoDB.Driver.Tests.Specifications.change_streams
             var test = CrudOperationTestFactory.CreateTest(name);
 
             var arguments = (BsonDocument)operation.GetValue("arguments", new BsonDocument());
-            string reason;
-            if (!test.CanExecute(DriverTestConfiguration.Client.Cluster.Description, arguments, out reason))
-            {
-                throw new SkipException(reason);
-            }
+            test.SkipIfNotSupported(arguments);
 
             var database = client.GetDatabase(operation["database"].AsString);
             var collection = database.GetCollection<BsonDocument>(operation["collection"].AsString);
-            test.Execute(DriverTestConfiguration.Client.Cluster.Description, database, collection, arguments, outcome: null, async: false);
+            test.Execute(DriverTestConfiguration.Client.Cluster.Description, database, collection, arguments, outcome: null, isErrorExpected: false, async: false);
         }
 
         private List<CommandStartedEvent> GetEvents(EventCapturer eventCapturer)

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/CrudTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/CrudTestRunner.cs
@@ -19,55 +19,217 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using MongoDB.Bson;
-using MongoDB.Bson.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Core;
+using MongoDB.Driver.Core.Events;
+using MongoDB.Driver.Core.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using MongoDB.Driver.TestHelpers;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Specifications.crud
 {
     public class CrudTestRunner
     {
+        #region static
+        private static readonly HashSet<string> __commandsToNotCapture = new HashSet<string>
+        {
+            "configureFailPoint",
+            "isMaster",
+            "buildInfo",
+            "getLastError",
+            "authenticate",
+            "saslStart",
+            "saslContinue",
+            "getnonce",
+            "find"
+        };
+        #endregion
+
+        private readonly EventCapturer _capturedEvents = new EventCapturer()
+            .Capture<CommandStartedEvent>(e => !__commandsToNotCapture.Contains(e.CommandName));
+
         [SkippableTheory]
         [ClassData(typeof(TestCaseFactory))]
         public void RunTestDefinition(BsonDocument definition, BsonDocument test, bool async)
         {
-            BsonValue minServerVersion;
-            if (definition.TryGetValue("minServerVersion", out minServerVersion))
+            SkipTestIfNeeded(definition, test);
+
+            var databaseName = DriverTestConfiguration.DatabaseNamespace.DatabaseName;
+            var collectionName = GetCollectionName(definition);
+            DropCollection(databaseName, collectionName);
+            PrepareData(databaseName, collectionName, definition);
+
+            using (var client = CreateDisposableClient(_capturedEvents))
+            {
+                var database = client.GetDatabase(databaseName);
+                var operations = test.Contains("operation")
+                    ? new[] { test["operation"].AsBsonDocument }
+                    : test["operations"].AsBsonArray.Cast<BsonDocument>();
+
+                foreach (var operation in operations)
+                {
+                    var collection = GetCollection(database, collectionName, operation);
+                    ExecuteOperation(client, database, collection, operation, (BsonDocument)test.GetValue("outcome", null), async);
+                }
+
+                AssertEventsIfNeeded(_capturedEvents, test);
+            }
+        }
+
+        private void AssertEvent(object actualEvent, BsonDocument expectedEvent)
+        {
+            if (expectedEvent.ElementCount != 1)
+            {
+                throw new FormatException("Expected event must be a document with a single element with a name the specifies the type of the event.");
+            }
+
+            var eventType = expectedEvent.GetElement(0).Name;
+            var eventAsserter = EventAsserterFactory.CreateAsserter(eventType);
+            eventAsserter.AssertAspects(actualEvent, expectedEvent[0].AsBsonDocument);
+        }
+
+        private void AssertEventsIfNeeded(EventCapturer eventCapturer, BsonDocument test)
+        {
+            if (test.TryGetValue("expectations", out var expectations))
+            {
+                var actualEvents = eventCapturer.Events;
+                var expectedEvents = expectations.AsBsonArray.Cast<BsonDocument>().ToList();
+
+                var minCount = Math.Min(actualEvents.Count, expectedEvents.Count);
+                for (var i = 0; i < minCount; i++)
+                {
+                    AssertEvent(actualEvents[i], expectedEvents[i]);
+                }
+
+                if (actualEvents.Count < expectedEvents.Count)
+                {
+                    throw new Exception($"Missing event: {expectedEvents[actualEvents.Count]}.");
+                }
+
+                if (actualEvents.Count > expectedEvents.Count)
+                {
+                    throw new Exception($"Unexpected event of type: {actualEvents[expectedEvents.Count].GetType().Name}.");
+                }
+            }
+        }
+
+        private DisposableMongoClient CreateDisposableClient(EventCapturer eventCapturer)
+        {
+            return DriverTestConfiguration.CreateDisposableClient(
+                (MongoClientSettings settings) =>
+                {
+                    settings.ClusterConfigurator = c =>
+                    {
+                        c = CoreTestConfiguration.ConfigureCluster(c);
+                        c.Subscribe(eventCapturer);
+                        c.ConfigureServer(ss => ss.With(heartbeatInterval: Timeout.InfiniteTimeSpan));
+                    };
+                });
+        }
+
+        private void DropCollection(string databaseName, string collectionName)
+        {
+            DriverTestConfiguration.Client.GetDatabase(databaseName).DropCollection(collectionName);
+        }
+
+        private void ExecuteOperation(IMongoClient client, IMongoDatabase database, IMongoCollection<BsonDocument> collection, BsonDocument operation, BsonDocument outcome, bool async)
+        {
+            var name = (string)operation["name"];
+            var test = CrudOperationTestFactory.CreateTest(name);
+            bool isErrorExpected = operation.GetValue("error", false).AsBoolean;
+
+            var arguments = (BsonDocument)operation.GetValue("arguments", new BsonDocument());
+            test.SkipIfNotSupported(arguments);
+
+            test.Execute(client.Cluster.Description, database, collection, arguments, outcome, isErrorExpected, async);
+
+            var threwException = test.ActualException != null;
+            if (isErrorExpected && !threwException)
+            {
+                throw new Exception("The test was expected to throw an exception, but no exception was thrown.");
+            }
+        }
+
+        private IMongoCollection<BsonDocument> GetCollection(IMongoDatabase database, string collectionName, BsonDocument operation)
+        {
+            var collectionSettings = ParseCollectionOptions(operation);
+
+            var collection = database.GetCollection<BsonDocument>(
+                collectionName,
+                collectionSettings);
+
+            return collection;
+        }
+
+        private string GetCollectionName(BsonDocument operation)
+        {
+            if (operation.TryGetValue("collection_name", out var collectionName))
+            {
+                return collectionName.AsString;
+            }
+            else
+            {
+                return DriverTestConfiguration.CollectionNamespace.CollectionName;
+            }
+        }
+
+        private void ParseCollectionOptions(MongoCollectionSettings settings, BsonDocument collectionOptions)
+        {
+            foreach (var collectionOption in collectionOptions.Elements)
+            {
+                switch (collectionOption.Name)
+                {
+                    case "readConcern":
+                        settings.ReadConcern = ReadConcern.FromBsonDocument(collectionOption.Value.AsBsonDocument);
+                        break;
+                    default:
+                        throw new FormatException($"Unexpected collection option: {collectionOption.Name}");
+                }
+            }
+        }
+
+        private MongoCollectionSettings ParseCollectionOptions(BsonDocument operation)
+        {
+            if (operation.TryGetValue("collectionOptions", out var collectionOptions))
+            {
+                var settings = new MongoCollectionSettings();
+                ParseCollectionOptions(settings, collectionOptions.AsBsonDocument);
+                return settings;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private void PrepareData(string databaseName, string collectionName, BsonDocument operation)
+        {
+            var data = operation["data"].AsBsonArray.Cast<BsonDocument>();
+            DriverTestConfiguration
+                .Client
+                .GetDatabase(databaseName)
+                .GetCollection<BsonDocument>(collectionName)
+                .InsertMany(data);
+        }
+
+        private void SkipTestIfNeeded(BsonDocument definition, BsonDocument test)
+        {
+            if (definition.TryGetValue("minServerVersion", out var minServerVersion))
             {
                 RequireServer.Check().VersionGreaterThanOrEqualTo(minServerVersion.AsString);
             }
 
-            BsonValue maxServerVersion;
-            if (definition.TryGetValue("maxServerVersion", out maxServerVersion))
+            if (definition.TryGetValue("maxServerVersion", out var maxServerVersion))
             {
                 RequireServer.Check().VersionLessThanOrEqualTo(maxServerVersion.AsString);
             }
 
-            var database = DriverTestConfiguration.Client
-                .GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
-            var collection = database
-                .GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);
-
-            database.DropCollection(collection.CollectionNamespace.CollectionName);
-            collection.InsertMany(definition["data"].AsBsonArray.Cast<BsonDocument>());
-
-            ExecuteOperation(database, collection, (BsonDocument)test["operation"], (BsonDocument)test["outcome"], async);
-        }
-
-        private void ExecuteOperation(IMongoDatabase database, IMongoCollection<BsonDocument> collection, BsonDocument operation, BsonDocument outcome, bool async)
-        {
-            var name = (string)operation["name"];
-            var test = CrudOperationTestFactory.CreateTest(name);
-
-            var arguments = (BsonDocument)operation.GetValue("arguments", new BsonDocument());
-            string reason;
-            if (!test.CanExecute(DriverTestConfiguration.Client.Cluster.Description, arguments, out reason))
+            if (test.TryGetValue("skipReason", out var reason))
             {
-                throw new SkipException(reason);
+                throw new SkipException(reason.AsString);
             }
-
-            test.Execute(DriverTestConfiguration.Client.Cluster.Description, database, collection, arguments, outcome, async);
         }
 
         private class TestCaseFactory : IEnumerable<object[]>
@@ -85,7 +247,7 @@ namespace MongoDB.Driver.Tests.Specifications.crud
                 {
                     foreach (BsonDocument test in definition["tests"].AsBsonArray)
                     {
-                        foreach (var async in new[] { false, true})
+                        foreach (var async in new[] { false, true })
                         {
                             //var testCase = new TestCaseData(definition, test, async);
                             //testCase.SetCategory("Specifications");

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/ICrudOperationTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/ICrudOperationTest.cs
@@ -14,18 +14,24 @@
 */
 
 using System;
-using System.Threading.Tasks;
-using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Clusters;
-using MongoDB.Driver.Core.Misc;
 
 namespace MongoDB.Driver.Tests.Specifications.crud
 {
     public interface ICrudOperationTest
     {
-        bool CanExecute(ClusterDescription clusterDescription, BsonDocument arguments, out string reason);
+        Exception ActualException { get; set; }
 
-        void Execute(ClusterDescription clusterDescription, IMongoDatabase database, IMongoCollection<BsonDocument> collection, BsonDocument arguments, BsonDocument outcome, bool async);
+        void Execute(
+            ClusterDescription clusterDescription, 
+            IMongoDatabase database, 
+            IMongoCollection<BsonDocument> collection, 
+            BsonDocument arguments, 
+            BsonDocument outcome, 
+            bool isErrorExpected,
+            bool async);
+
+        void SkipIfNotSupported(BsonDocument arguments);
     }
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/read/aggregate-out-readConcern.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/read/aggregate-out-readConcern.json
@@ -1,0 +1,379 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "minServerVersion": "4.1",
+  "collection_name": "test_aggregate_out_readconcern",
+  "tests": [
+    {
+      "description": "readConcern majority with out stage",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "majority"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readConcern local with out stage",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "local"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "local"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readConcern available with out stage",
+      "skipReason": "should be implemented in the scope of CSHARP-2382",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "available"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "available"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readConcern linearizable with out stage",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "linearizable"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "linearizable"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "invalid readConcern with out stage",
+      "skipReason": "the test is not applicable for the current c# implementation since we don't send unrecognized `readConcern` value to the server",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "!invalid123"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "!invalid123"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/tests/read/aggregate-out-readConcern.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/tests/read/aggregate-out-readConcern.yml
@@ -1,0 +1,107 @@
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+    - { _id: 3, x: 33 }
+
+minServerVersion: '4.1'
+
+collection_name: &collection_name 'test_aggregate_out_readconcern'
+
+tests:
+  -
+    description: "readConcern majority with out stage"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        collectionOptions:
+          readConcern: { level: "majority" }
+        arguments: &arguments
+          pipeline:
+            - $sort: { x : 1 }
+            - $match: { _id: { $gt: 1 } }
+            - $out: &output_collection "other_test_collection"
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: &pipeline
+              - $sort: { x: 1 }
+              - $match: { _id: { $gt: 1 } }
+              - $out: "other_test_collection"
+            readConcern: { level: "majority" }
+    outcome: &outcome
+      collection:
+        name: *output_collection
+        data:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+  -
+    description: "readConcern local with out stage"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        collectionOptions:
+          readConcern: { level: "local" }
+        arguments: *arguments
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *pipeline
+            readConcern: { level: "local" }
+    outcome: *outcome
+  -
+    description: "readConcern available with out stage"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        collectionOptions:
+          readConcern: { level: "available" }
+        arguments: *arguments
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *pipeline
+            readConcern: { level: "available" }
+    outcome: *outcome
+  -
+    description: "readConcern linearizable with out stage"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        collectionOptions:
+          readConcern: { level: "linearizable" }
+        arguments: *arguments
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *pipeline
+            readConcern: { level: "linearizable" }
+  -
+    description: "invalid readConcern with out stage"
+    operations:
+      -
+        object: collection
+        name: aggregate
+        collectionOptions:
+          readConcern: { level: "!invalid123" }
+        arguments: *arguments
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline: *pipeline
+            readConcern: { level: "!invalid123" }


### PR DESCRIPTION
Spec diff: https://github.com/mongodb/specifications/pull/475/files
Evergreeen: https://evergreen.mongodb.com/version/5ce2d482d1fe07645b98e48e