### PR TITLE
CSHARP-2612: Make errors with NonResumableChangeStreamError non resumable.

### DIFF
--- a/tests/MongoDB.Driver.Core.TestHelpers/CoreExceptionHelper.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/CoreExceptionHelper.cs
@@ -75,7 +75,7 @@ namespace MongoDB.Driver.Core.TestHelpers
             }
         }
 
-        public static MongoCommandException CreateMongoCommandException(int code)
+        public static MongoCommandException CreateMongoCommandException(int code = 1, string label = null)
         {
             var clusterId = new ClusterId(1);
             var endPoint = new DnsEndPoint("localhost", 27017);
@@ -84,7 +84,13 @@ namespace MongoDB.Driver.Core.TestHelpers
             var message = "Fake MongoCommandException";
             var command = BsonDocument.Parse("{ command : 1 }");
             var result = BsonDocument.Parse($"{{ ok: 0, code : {code} }}");
-            return new MongoCommandException(connectionId, message, command, result);
+            var commandException = new MongoCommandException(connectionId, message, command, result);
+            if (label != null)
+            {
+                commandException.AddErrorLabel(label);
+            }
+
+            return commandException;
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/RetryabilityHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/RetryabilityHelperTests.cs
@@ -46,6 +46,17 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         [Theory]
+        [InlineData("NonResumableChangeStreamError", false)]
+        public void IsResumableChangeStreamException_should_return_expected_result_using_error_label(string label, bool expectedResult)
+        {
+            var exception = CoreExceptionHelper.CreateMongoCommandException(label: label);
+
+            var result = RetryabilityHelper.IsResumableChangeStreamException(exception);
+
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
         [InlineData(typeof(IOException), false)]
         [InlineData(typeof(MongoConnectionException), true)]
         [InlineData(typeof(MongoCursorNotFoundException), true)]

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/change-streams-errors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/change-streams-errors.json
@@ -73,6 +73,43 @@
           "code": 40324
         }
       }
+    },
+    {
+      "description": "Change Stream should error when _id is projected out",
+      "minServerVersion": "4.1.11",
+      "target": "collection",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ],
+      "changeStreamPipeline": [
+        {
+          "$project": {
+            "_id": 0
+          }
+        }
+      ],
+      "changeStreamOptions": {},
+      "operations": [
+        {
+          "database": "change-stream-tests",
+          "collection": "test",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "z": 3
+            }
+          }
+        }
+      ],
+      "result": {
+        "error": {
+          "code": 280,
+          "errorLabels": [
+            "NonResumableChangeStreamError"
+          ]
+        }
+      }
     }
   ]
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/change-streams-errors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/change-streams/tests/change-streams-errors.yml
@@ -51,3 +51,26 @@ tests:
     result:
       error:
         code: 40324
+  -
+    description: Change Stream should error when _id is projected out
+    minServerVersion: "4.1.11"
+    target: collection
+    topology:
+      - replicaset
+      - sharded
+    changeStreamPipeline:
+      -
+        $project: { _id: 0 }
+    changeStreamOptions: {}
+    operations:
+      -
+        database: *database_name
+        collection: *collection_name
+        name: insertOne
+        arguments:
+          document:
+            z: 3
+    result:
+      error:
+        code: 280
+errorLabels: [ "NonResumableChangeStreamError" ]


### PR DESCRIPTION
Evergreen:  https://evergreen.mongodb.com/version/5d039a9157e85a0a418eede2

**NOTE**: currently the spec description contains mentioning of `NonRetryableChangeStreamError`, but probably it should be `NonResumableChangeStreamError`. I've asked question to the spec commit author. As soon as she answers, I will add her answer here.

https://github.com/mongodb/specifications/commit/64c5cddb5cb1d23137b60b18f0bcb8de1a21bedc#diff-875f237661962b4ca9b2e58d97449831R50