### PR TITLE
CSHARP-2344: Update ChangeStream tests for 4.1.1 "drop" notifications.

### DIFF
--- a/src/MongoDB.Driver.Core/ChangeStreamOperationType.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamOperationType.cs
@@ -43,6 +43,10 @@ namespace MongoDB.Driver
         /// <summary>
         /// A rename operation type.
         /// </summary>
-        Rename
+        Rename,
+        /// <summary>
+        /// A drop operation type.
+        /// </summary>
+        Drop
     }
 }

--- a/src/MongoDB.Driver.Core/ChangeStreamOperationTypeSerializer.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamOperationTypeSerializer.cs
@@ -52,6 +52,7 @@ namespace MongoDB.Driver
                 case "replace": return ChangeStreamOperationType.Replace;
                 case "update": return ChangeStreamOperationType.Update;
                 case "rename": return ChangeStreamOperationType.Rename;
+                case "drop": return ChangeStreamOperationType.Drop;
                 default: throw new FormatException($"Invalid ChangeStreamOperationType: \"{stringValue}\".");
             }
         }
@@ -69,6 +70,7 @@ namespace MongoDB.Driver
                 case ChangeStreamOperationType.Replace: writer.WriteString("replace"); break;
                 case ChangeStreamOperationType.Update: writer.WriteString("update"); break;
                 case ChangeStreamOperationType.Rename: writer.WriteString("rename"); break;
+                case ChangeStreamOperationType.Drop: writer.WriteString("drop"); break;
                 default: throw new ArgumentException($"Invalid ChangeStreamOperationType: {value}.", nameof(value));
             }
         }

--- a/tests/MongoDB.Driver.Core.Tests/ChangeStreamDocumentTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/ChangeStreamDocumentTests.cs
@@ -177,6 +177,7 @@ namespace MongoDB.Driver
         [InlineData("replace", ChangeStreamOperationType.Replace)]
         [InlineData("delete", ChangeStreamOperationType.Delete)]
         [InlineData("rename", ChangeStreamOperationType.Rename)]
+        [InlineData("drop", ChangeStreamOperationType.Drop)]
         public void OperationType_should_return_expected_result(string operationTypeName, ChangeStreamOperationType expectedResult)
         {
             var backingDocument = new BsonDocument { { "other", 1 }, { "operationType", operationTypeName } };

--- a/tests/MongoDB.Driver.Core.Tests/ChangeStreamOperationTypeSerializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/ChangeStreamOperationTypeSerializerTests.cs
@@ -31,6 +31,7 @@ namespace MongoDB.Driver
         [InlineData("\"replace\"", ChangeStreamOperationType.Replace)]
         [InlineData("\"update\"", ChangeStreamOperationType.Update)]
         [InlineData("\"rename\"", ChangeStreamOperationType.Rename)]
+        [InlineData("\"drop\"", ChangeStreamOperationType.Drop)]
         public void Deserialize_should_return_expected_result(string json, ChangeStreamOperationType expectedResult)
         {
             var subject = CreateSubject();
@@ -69,6 +70,7 @@ namespace MongoDB.Driver
         [InlineData(ChangeStreamOperationType.Replace, "\"replace\"")]
         [InlineData(ChangeStreamOperationType.Update, "\"update\"")]
         [InlineData(ChangeStreamOperationType.Rename, "\"rename\"")]
+        [InlineData(ChangeStreamOperationType.Drop, "\"drop\"")]
         public void Serialize_should_have_expected_result(ChangeStreamOperationType value, string expectedResult)
         {
             var subject = CreateSubject();
@@ -87,7 +89,7 @@ namespace MongoDB.Driver
 
         [Theory]
         [InlineData(-1)]
-        [InlineData(6)]
+        [InlineData(7)]
         public void Serialize_should_throw_when_value_is_invalid(int valueAsInt)
         {
             var subject = CreateSubject();


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5d03a7a17742ae15307847ad