### PR TITLE
CSHARP-2639: Update ChangeStreamDocument by a new field from `rename` event. Add `rename` change stream operation type.

### DIFF
--- a/src/MongoDB.Driver.Core/ChangeStreamDocument.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamDocument.cs
@@ -86,6 +86,14 @@ namespace MongoDB.Driver
         public ChangeStreamOperationType OperationType => GetValue<ChangeStreamOperationType>(nameof(OperationType), (ChangeStreamOperationType)(-1));
 
         /// <summary>
+        /// Gets the new namespace for the ns collection. This field is omitted for all operation types except "rename".
+        /// </summary>
+        /// <value>
+        /// The new namespace of the ns collection.
+        /// </value>
+        public CollectionNamespace RenameTo => GetValue<CollectionNamespace>(nameof(RenameTo), null);
+
+        /// <summary>
         /// Gets the resume token.
         /// </summary>
         /// <value>

--- a/src/MongoDB.Driver.Core/ChangeStreamDocumentSerializer.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamDocumentSerializer.cs
@@ -45,6 +45,7 @@ namespace MongoDB.Driver
             RegisterMember("DocumentKey", "documentKey", BsonDocumentSerializer.Instance);
             RegisterMember("FullDocument", "fullDocument", _documentSerializer);
             RegisterMember("OperationType", "operationType", ChangeStreamOperationTypeSerializer.Instance);
+            RegisterMember("RenameTo", "to", ChangeStreamDocumentCollectionNamespaceSerializer.Instance);
             RegisterMember("ResumeToken", "_id", BsonDocumentSerializer.Instance);
             RegisterMember("UpdateDescription", "updateDescription", ChangeStreamUpdateDescriptionSerializer.Instance);
         }

--- a/src/MongoDB.Driver.Core/ChangeStreamOperationType.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamOperationType.cs
@@ -39,6 +39,10 @@ namespace MongoDB.Driver
         /// <summary>
         /// An invalidate operation type.
         /// </summary>
-        Invalidate
+        Invalidate,
+        /// <summary>
+        /// A rename operation type.
+        /// </summary>
+        Rename
     }
 }

--- a/src/MongoDB.Driver.Core/ChangeStreamOperationTypeSerializer.cs
+++ b/src/MongoDB.Driver.Core/ChangeStreamOperationTypeSerializer.cs
@@ -51,6 +51,7 @@ namespace MongoDB.Driver
                 case "invalidate": return ChangeStreamOperationType.Invalidate;
                 case "replace": return ChangeStreamOperationType.Replace;
                 case "update": return ChangeStreamOperationType.Update;
+                case "rename": return ChangeStreamOperationType.Rename;
                 default: throw new FormatException($"Invalid ChangeStreamOperationType: \"{stringValue}\".");
             }
         }
@@ -67,6 +68,7 @@ namespace MongoDB.Driver
                 case ChangeStreamOperationType.Invalidate: writer.WriteString("invalidate"); break;
                 case ChangeStreamOperationType.Replace: writer.WriteString("replace"); break;
                 case ChangeStreamOperationType.Update: writer.WriteString("update"); break;
+                case ChangeStreamOperationType.Rename: writer.WriteString("rename"); break;
                 default: throw new ArgumentException($"Invalid ChangeStreamOperationType: {value}.", nameof(value));
             }
         }

--- a/tests/MongoDB.Driver.Core.Tests/ChangeStreamDocumentSerializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/ChangeStreamDocumentSerializerTests.cs
@@ -36,12 +36,13 @@ namespace MongoDB.Driver
             var result = new ChangeStreamDocumentSerializer<BsonDocument>(documentSerializer);
 
             result._documentSerializer().Should().BeSameAs(documentSerializer);
-            result._memberSerializationInfo().Count.Should().Be(7);
+            result._memberSerializationInfo().Count.Should().Be(8);
             AssertRegisteredMember(result, "ClusterTime", "clusterTime", BsonTimestampSerializer.Instance);
             AssertRegisteredMember(result, "CollectionNamespace", "ns", ChangeStreamDocumentCollectionNamespaceSerializer.Instance);
             AssertRegisteredMember(result, "DocumentKey", "documentKey", BsonDocumentSerializer.Instance);
             AssertRegisteredMember(result, "FullDocument", "fullDocument", documentSerializer);
             AssertRegisteredMember(result, "OperationType", "operationType", ChangeStreamOperationTypeSerializer.Instance);
+            AssertRegisteredMember(result, "RenameTo", "to", ChangeStreamDocumentCollectionNamespaceSerializer.Instance);
             AssertRegisteredMember(result, "ResumeToken", "_id", BsonDocumentSerializer.Instance);
             AssertRegisteredMember(result, "UpdateDescription", "updateDescription", ChangeStreamUpdateDescriptionSerializer.Instance);
         }

--- a/tests/MongoDB.Driver.Core.Tests/ChangeStreamDocumentTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/ChangeStreamDocumentTests.cs
@@ -176,6 +176,7 @@ namespace MongoDB.Driver
         [InlineData("update", ChangeStreamOperationType.Update)]
         [InlineData("replace", ChangeStreamOperationType.Replace)]
         [InlineData("delete", ChangeStreamOperationType.Delete)]
+        [InlineData("rename", ChangeStreamOperationType.Rename)]
         public void OperationType_should_return_expected_result(string operationTypeName, ChangeStreamOperationType expectedResult)
         {
             var backingDocument = new BsonDocument { { "other", 1 }, { "operationType", operationTypeName } };
@@ -196,6 +197,31 @@ namespace MongoDB.Driver
             var result = subject.OperationType;
 
             result.Should().Be((ChangeStreamOperationType)(-1));
+        }
+
+        [Fact]
+        public void RenameTo_should_return_expected_result()
+        {
+            var value = new CollectionNamespace(new DatabaseNamespace("database"), "collection");
+            var to = new BsonDocument { { "db", value.DatabaseNamespace.DatabaseName }, { "coll", value.CollectionName } };
+            var backingDocument = new BsonDocument { { "other", 1 }, { "to", to } };
+            var subject = CreateSubject(backingDocument: backingDocument);
+
+            var result = subject.RenameTo;
+
+            result.Should().Be(value);
+        }
+
+        [Fact]
+        public void RenameTo_should_return_null_when_not_present()
+        {
+            var value = new BsonDocument("x", 1234);
+            var backingDocument = new BsonDocument { { "other", 1 } };
+            var subject = CreateSubject(backingDocument: backingDocument);
+
+            var result = subject.RenameTo;
+
+            result.Should().BeNull();
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Core.Tests/ChangeStreamOperationTypeSerializerTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/ChangeStreamOperationTypeSerializerTests.cs
@@ -30,6 +30,7 @@ namespace MongoDB.Driver
         [InlineData("\"invalidate\"", ChangeStreamOperationType.Invalidate)]
         [InlineData("\"replace\"", ChangeStreamOperationType.Replace)]
         [InlineData("\"update\"", ChangeStreamOperationType.Update)]
+        [InlineData("\"rename\"", ChangeStreamOperationType.Rename)]
         public void Deserialize_should_return_expected_result(string json, ChangeStreamOperationType expectedResult)
         {
             var subject = CreateSubject();
@@ -67,6 +68,7 @@ namespace MongoDB.Driver
         [InlineData(ChangeStreamOperationType.Invalidate, "\"invalidate\"")]
         [InlineData(ChangeStreamOperationType.Replace, "\"replace\"")]
         [InlineData(ChangeStreamOperationType.Update, "\"update\"")]
+        [InlineData(ChangeStreamOperationType.Rename, "\"rename\"")]
         public void Serialize_should_have_expected_result(ChangeStreamOperationType value, string expectedResult)
         {
             var subject = CreateSubject();
@@ -85,7 +87,7 @@ namespace MongoDB.Driver
 
         [Theory]
         [InlineData(-1)]
-        [InlineData(5)]
+        [InlineData(6)]
         public void Serialize_should_throw_when_value_is_invalid(int valueAsInt)
         {
             var subject = CreateSubject();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/ChangeStreamOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/ChangeStreamOperationTests.cs
@@ -412,6 +412,7 @@ namespace MongoDB.Driver.Core.Operations
                 change.CollectionNamespace.Should().BeNull();
                 change.DocumentKey.Should().BeNull();
                 change.FullDocument.Should().BeNull();
+                change.RenameTo.Should().BeNull();
                 change.ResumeToken.Should().NotBeNull();
                 change.UpdateDescription.Should().BeNull();
             }
@@ -442,6 +443,7 @@ namespace MongoDB.Driver.Core.Operations
                 change.CollectionNamespace.Should().Be(_collectionNamespace);
                 change.DocumentKey.Should().Be("{ _id : 1 }");
                 change.FullDocument.Should().BeNull();
+                change.RenameTo.Should().BeNull();
                 change.ResumeToken.Should().NotBeNull();
                 change.UpdateDescription.Should().BeNull();
             }
@@ -473,6 +475,7 @@ namespace MongoDB.Driver.Core.Operations
                 change.CollectionNamespace.Should().Be(_collectionNamespace);
                 change.DocumentKey.Should().Be("{ _id : 2 }");
                 change.FullDocument.Should().Be("{ _id : 2, x : 2 }");
+                change.RenameTo.Should().BeNull();
                 change.ResumeToken.Should().NotBeNull();
                 change.UpdateDescription.Should().BeNull();
             }
@@ -550,6 +553,7 @@ namespace MongoDB.Driver.Core.Operations
                 change.CollectionNamespace.Should().Be(_collectionNamespace);
                 change.DocumentKey.Should().Be("{ _id : 1 }");
                 change.FullDocument.Should().Be(fullDocument == ChangeStreamFullDocumentOption.Default ? null : "{ _id : 1, x : 2 }");
+                change.RenameTo.Should().BeNull();
                 change.ResumeToken.Should().NotBeNull();
                 change.UpdateDescription.RemovedFields.Should().BeEmpty();
                 change.UpdateDescription.UpdatedFields.Should().Be("{ x : 2 }");


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5d03e6df57e85a0a41942938