### PR TITLE
CSHARP-2614: Fix logic for projection where one field name starts with another field name.

### DIFF
--- a/src/MongoDB.Driver/Linq/Translators/FindProjectionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/FindProjectionTranslator.cs
@@ -89,7 +89,9 @@ namespace MongoDB.Driver.Linq.Translators
 
         protected internal override Expression VisitField(FieldExpression node)
         {
-            if (!_fields.Any(x => x.FieldName == node.FieldName
+            var dottedFieldExpression = GetDottedFieldExpression(node);
+
+            if (!_fields.Any(x => x.FieldName == dottedFieldExpression.FieldName
                 && x.Serializer.ValueType == node.Serializer.ValueType))
             {
                 // we need to unwind this call...
@@ -100,7 +102,7 @@ namespace MongoDB.Driver.Linq.Translators
                 _parameterExpression,
                 "GetValue",
                 new[] { node.Type },
-                Expression.Constant(node.FieldName),
+                Expression.Constant(dottedFieldExpression.FieldName),
                 Expression.Constant(node.Serializer.ValueType.GetDefaultValue(), typeof(object)));
         }
 
@@ -156,6 +158,30 @@ namespace MongoDB.Driver.Linq.Translators
             return base.VisitDocument(node);
         }
 
+        private FieldExpression GetDottedFieldExpression(FieldExpression node)
+        {
+            var fieldNames = new List<string> { node.FieldName };
+            var document = node.Document as FieldExpression;
+            while (document != null)
+            {
+                fieldNames.Add(document.FieldName);
+                document = document.Document as FieldExpression;
+            }
+
+            string dottedFieldName;
+            if (fieldNames.Count > 1)
+            {
+                fieldNames.Reverse();
+                dottedFieldName = string.Join(".", fieldNames);
+            }
+            else
+            {
+                dottedFieldName = fieldNames[0];
+            }
+
+            return new FieldExpression(null, dottedFieldName, node.Serializer, node.Original);
+        }
+
         private static BsonDocument GetProjectionDocument(IEnumerable<BsonSerializationInfo> used)
         {
             var includeId = false;
@@ -192,7 +218,12 @@ namespace MongoDB.Driver.Linq.Translators
                 var referenceGroup = referenceGroups.Dequeue();
                 if (!skippedFields.Contains(referenceGroup.Key))
                 {
-                    var hierarchicalReferenceGroups = referenceGroups.Where(x => x.Key.StartsWith(referenceGroup.Key));
+                    var hierarchicalReferenceGroups = referenceGroups
+                        .Where(x =>
+                        {
+                            return x.Key.Count(c => c == '.') != referenceGroup.Key.Count(c => c == '.') && // otherwise, fields are on the same nesting level
+                                   x.Key.StartsWith(referenceGroup.Key);
+                        });
                     uniqueFields.AddRange(referenceGroup);
                     skippedFields.AddRange(hierarchicalReferenceGroups.Select(x => x.Key));
                 }


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5d0a15d91e2d1760d8d5aaae
