### PR TITLE
CSHARP-2616: Allow applications to set maxTimeMS for commitTransaction.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Bindings/CoreSession.cs
+++ b/src/MongoDB.Driver.Core/Core/Bindings/CoreSession.cs
@@ -376,7 +376,9 @@ namespace MongoDB.Driver.Core.Bindings
 
         private IReadOperation<BsonDocument> CreateCommitTransactionOperation(bool isCommitRetry)
         {
-            return new CommitTransactionOperation(_currentTransaction.RecoveryToken, GetCommitTransactionWriteConcern(isCommitRetry));
+            var writeConcern = GetCommitTransactionWriteConcern(isCommitRetry);
+            var maxCommitTime = _currentTransaction.TransactionOptions.MaxCommitTime;
+            return new CommitTransactionOperation(_currentTransaction.RecoveryToken, writeConcern) { MaxCommitTime = maxCommitTime };
         }
 
         private void EnsureAbortTransactionCanBeCalled(string methodName)
@@ -490,7 +492,8 @@ namespace MongoDB.Driver.Core.Bindings
             var readConcern = transactionOptions?.ReadConcern ?? _options.DefaultTransactionOptions?.ReadConcern ?? ReadConcern.Default;
             var readPreference = transactionOptions?.ReadPreference ?? _options.DefaultTransactionOptions?.ReadPreference ?? ReadPreference.Primary;
             var writeConcern = transactionOptions?.WriteConcern ?? _options.DefaultTransactionOptions?.WriteConcern ?? new WriteConcern();
-            return new TransactionOptions(readConcern, readPreference, writeConcern);
+            var maxCommitTime = transactionOptions?.MaxCommitTime ?? _options.DefaultTransactionOptions?.MaxCommitTime;
+            return new TransactionOptions(readConcern, readPreference, writeConcern, maxCommitTime);
         }
 
         private WriteConcern GetTransactionWriteConcern()

--- a/src/MongoDB.Driver.Core/Core/Misc/ExceptionMapper.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/ExceptionMapper.cs
@@ -44,7 +44,7 @@ namespace MongoDB.Driver.Core.Misc
                     case 13475:
                     case 16986:
                     case 16712:
-                        return new MongoExecutionTimeoutException(connectionId, message: "Operation exceeded time limit.");
+                        return new MongoExecutionTimeoutException(connectionId, message: "Operation exceeded time limit.", response);
                 }
             }
 

--- a/src/MongoDB.Driver.Core/MongoExecutionTimeoutException.cs
+++ b/src/MongoDB.Driver.Core/MongoExecutionTimeoutException.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using MongoDB.Bson;
 #if NET452
 using System.Runtime.Serialization;
 #endif
@@ -29,6 +30,8 @@ namespace MongoDB.Driver
 #endif
     public class MongoExecutionTimeoutException : MongoServerException
     {
+        private readonly BsonDocument _result;
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoExecutionTimeoutException"/> class.
@@ -51,6 +54,30 @@ namespace MongoDB.Driver
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoExecutionTimeoutException"/> class.
+        /// </summary>
+        /// <param name="connectionId">The connection identifier.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="result">The command result.</param>
+        public MongoExecutionTimeoutException(ConnectionId connectionId, string message, BsonDocument result)
+            : this(connectionId, message, null, result)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoExecutionTimeoutException"/> class.
+        /// </summary>
+        /// <param name="connectionId">The connection identifier.</param>
+        /// <param name="message">The error message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <param name="result">The command result.</param>
+        public MongoExecutionTimeoutException(ConnectionId connectionId, string message, Exception innerException, BsonDocument result)
+            : base(connectionId, message, innerException)
+        {
+            _result = result;
+        }
+
 #if NET452
         /// <summary>
         /// Initializes a new instance of the <see cref="MongoExecutionTimeoutException"/> class.
@@ -62,5 +89,25 @@ namespace MongoDB.Driver
         {
         }
 #endif
+
+        // properties
+        /// <summary>
+        /// Gets the error code.
+        /// </summary>
+        /// <value>
+        /// The error code.
+        /// </value>
+        public int Code =>
+            _result != null && _result.TryGetValue("code", out var code)
+                ? code.ToInt32()
+                : -1;
+
+        /// <summary>
+        /// Gets the name of the error code.
+        /// </summary>
+        /// <value>
+        /// The name of the error code.
+        /// </value>
+        public string CodeName => _result?.GetValue("codeName", null)?.AsString;
     }
 }

--- a/src/MongoDB.Driver.Core/TransactionOptions.cs
+++ b/src/MongoDB.Driver.Core/TransactionOptions.cs
@@ -14,11 +14,6 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MongoDB.Bson;
 
 namespace MongoDB.Driver
 {
@@ -28,6 +23,7 @@ namespace MongoDB.Driver
     public class TransactionOptions
     {
         // private fields
+        private readonly TimeSpan? _maxCommitTime;
         private readonly ReadConcern _readConcern;
         private readonly ReadPreference _readPreference;
         private readonly WriteConcern _writeConcern;
@@ -39,17 +35,28 @@ namespace MongoDB.Driver
         /// <param name="readConcern">The read concern.</param>
         /// <param name="readPreference">The read preference.</param>
         /// <param name="writeConcern">The write concern.</param>
+        /// <param name="maxCommitTime">The max commit time.</param>
         public TransactionOptions(
             Optional<ReadConcern> readConcern = default(Optional<ReadConcern>),
             Optional<ReadPreference> readPreference = default(Optional<ReadPreference>),
-            Optional<WriteConcern> writeConcern = default(Optional<WriteConcern>))
+            Optional<WriteConcern> writeConcern = default(Optional<WriteConcern>),
+            Optional<TimeSpan?> maxCommitTime = default(Optional<TimeSpan?>))
         {
             _readConcern = readConcern.WithDefault(null);
             _readPreference = readPreference.WithDefault(null);
             _writeConcern = writeConcern.WithDefault(null);
+            _maxCommitTime = maxCommitTime.WithDefault(null);
         }
 
         // public properties
+        /// <summary>
+        /// Gets the max commit time.
+        /// </summary>
+        /// <value>
+        /// The max commit time.
+        /// </value>
+        public TimeSpan? MaxCommitTime => _maxCommitTime;
+
         /// <summary>
         /// Gets the read concern.
         /// </summary>
@@ -81,18 +88,21 @@ namespace MongoDB.Driver
         /// <param name="readConcern">The new read concern.</param>
         /// <param name="readPreference">The read preference.</param>
         /// <param name="writeConcern">The new write concern.</param>
+        /// <param name="maxCommitTime">The max commit time.</param>
         /// <returns>
         /// The new TransactionOptions.
         /// </returns>
         public TransactionOptions With(
             Optional<ReadConcern> readConcern = default(Optional<ReadConcern>),
             Optional<ReadPreference> readPreference = default(Optional<ReadPreference>),
-            Optional<WriteConcern> writeConcern = default(Optional<WriteConcern>))
+            Optional<WriteConcern> writeConcern = default(Optional<WriteConcern>),
+            Optional<TimeSpan?> maxCommitTime = default(Optional<TimeSpan?>))
         {
             return new TransactionOptions(
                 readConcern: readConcern.WithDefault(_readConcern),
                 readPreference: readPreference.WithDefault(_readPreference),
-                writeConcern: writeConcern.WithDefault(_writeConcern));
+                writeConcern: writeConcern.WithDefault(_writeConcern),
+                maxCommitTime: maxCommitTime.WithDefault(_maxCommitTime));
         }
     }
 }

--- a/src/MongoDB.Driver/ClientSessionHandle.cs
+++ b/src/MongoDB.Driver/ClientSessionHandle.cs
@@ -166,8 +166,9 @@ namespace MongoDB.Driver
             var readConcern = transactionOptions?.ReadConcern ?? defaultTransactionOptions?.ReadConcern ?? _client.Settings?.ReadConcern ?? ReadConcern.Default;
             var readPreference = transactionOptions?.ReadPreference ?? defaultTransactionOptions?.ReadPreference ?? _client.Settings?.ReadPreference ?? ReadPreference.Primary;
             var writeConcern = transactionOptions?.WriteConcern ?? defaultTransactionOptions?.WriteConcern ?? _client.Settings?.WriteConcern ?? new WriteConcern();
+            var maxCommitTime = transactionOptions?.MaxCommitTime ?? defaultTransactionOptions?.MaxCommitTime;
 
-            return new TransactionOptions(readConcern, readPreference, writeConcern);
+            return new TransactionOptions(readConcern, readPreference, writeConcern, maxCommitTime);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.TestHelpers/JsonDrivenTests/CommandStartedEventAsserter.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/JsonDrivenTests/CommandStartedEventAsserter.cs
@@ -100,6 +100,7 @@ namespace MongoDB.Driver.Core.TestHelpers.JsonDrivenTests
                     case "startTransaction":
                     case "txnNumber":
                     case "writeConcern":
+                    case "maxTimeMS":
                         if (actualCommand.Contains(name))
                         {
                             throw new AssertionFailedException($"Did not expect field '{name}' in command: {actualCommand.ToJson()}.");
@@ -130,7 +131,7 @@ namespace MongoDB.Driver.Core.TestHelpers.JsonDrivenTests
                 AdaptExpectedUpdateModels(actualValue.AsBsonArray.Cast<BsonDocument>().ToList(), expectedValue.AsBsonArray.Cast<BsonDocument>().ToList());
             }
 
-            var namesToUseOrderInsensitiveComparisonWith = new[] { "writeConcern" };
+            var namesToUseOrderInsensitiveComparisonWith = new[] { "writeConcern", "maxTimeMS" };
             var useOrderInsensitiveComparison = namesToUseOrderInsensitiveComparisonWith.Contains(name);
 
             if (!(useOrderInsensitiveComparison ? BsonValueEquivalencyComparer.Compare(actualValue, expectedValue) : actualValue.Equals(expectedValue)))

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAggregateTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenAggregateTest.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -92,6 +93,10 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
 
                 case "session":
                     _session = (IClientSessionHandle)_objectMap[value.AsString];
+                    return;
+
+                case "maxTimeMS":
+                    _options.MaxTime = TimeSpan.FromMilliseconds(value.ToInt32());
                     return;
             }
 

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenCommandTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenCommandTest.cs
@@ -51,6 +51,11 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
                     }
                 }
 
+                if (actualErrorCodeName == null && _actualException is MongoExecutionTimeoutException mongoExecutionTimeout)
+                {
+                    actualErrorCodeName = mongoExecutionTimeout.CodeName;
+                }
+
                 if (actualErrorCodeName == null)
                 {
                     throw new Exception("Exception was missing \"errorCodeName\".");

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenStartTransactionTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenStartTransactionTest.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -70,7 +71,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
         // private methods
         private TransactionOptions ParseOptions(BsonDocument document)
         {
-            JsonDrivenHelper.EnsureAllFieldsAreValid(document, "readConcern", "readPreference", "writeConcern");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(document, "readConcern", "readPreference", "writeConcern", "maxCommitTimeMS");
 
             var options = new TransactionOptions();
             if (document.Contains("readConcern"))
@@ -86,6 +87,11 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             if (document.Contains("writeConcern"))
             {
                 options = options.With(writeConcern: WriteConcern.FromBsonDocument(document["writeConcern"].AsBsonDocument));
+            }
+
+            if (document.Contains("maxCommitTimeMS"))
+            {
+                options = options.With(maxCommitTime: TimeSpan.FromMilliseconds(document["maxCommitTimeMS"].ToInt32()));
             }
 
             return options;

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenWithTransactionTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenWithTransactionTest.cs
@@ -88,7 +88,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
         // private methods
         private TransactionOptions ParseTransactionOptions(BsonDocument document)
         {
-            JsonDrivenHelper.EnsureAllFieldsAreValid(document, "readConcern", "readPreference", "writeConcern");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(document, "readConcern", "readPreference", "writeConcern", "maxCommitTimeMS");
 
             var options = new TransactionOptions();
             if (document.Contains("readConcern"))
@@ -104,6 +104,11 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
             if (document.Contains("writeConcern"))
             {
                 options = options.With(writeConcern: WriteConcern.FromBsonDocument(document["writeConcern"].AsBsonDocument));
+            }
+
+            if (document.Contains("maxCommitTimeMS"))
+            {
+                options = options.With(maxCommitTime: TimeSpan.FromMilliseconds(document["maxCommitTimeMS"].ToInt32()));
             }
 
             return options;

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/TransactionsConvenientApiTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/TransactionsConvenientApiTestRunner.cs
@@ -17,9 +17,6 @@ using System.Collections.Generic;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core;
-using MongoDB.Driver.Core.Clusters;
-using MongoDB.Driver.Core.Misc;
-using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Tests.Specifications.Runner;
 using Xunit;
 

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/tests/commit-retry.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/tests/commit-retry.json
@@ -423,6 +423,106 @@
           ]
         }
       }
+    },
+    {
+      "description": "commit is not retried after MaxTimeMSExpired error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            },
+            "options": {
+              "maxCommitTimeMS": 60000
+            }
+          },
+          "result": {
+            "errorCodeName": "MaxTimeMSExpired",
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "maxTimeMS": 60000,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
     }
   ]
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/tests/commit-retry.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/tests/commit-retry.yml
@@ -21,7 +21,7 @@ tests:
           failCommands: ["commitTransaction"]
           closeConnection: true
     operations:
-      -
+      - &withTransaction
         name: withTransaction
         object: session0
         arguments:
@@ -194,20 +194,7 @@ tests:
           errorCode: 10107 # NotMaster
           closeConnection: false
     operations:
-      -
-        name: withTransaction
-        object: session0
-        arguments:
-          callback:
-            operations:
-              -
-                name: insertOne
-                object: collection
-                arguments:
-                  session: session0
-                  document: { _id: 1 }
-                result:
-                  insertedId: 1
+      - *withTransaction
     expectations:
       -
         command_started_event:
@@ -270,3 +257,68 @@ tests:
       collection:
         data:
           - { _id: 1 }
+  -
+    description: commit is not retried after MaxTimeMSExpired error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 50 # MaxTimeMSExpired
+    operations:
+      - name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+          options:
+            maxCommitTimeMS: 60000
+        result:
+          errorCodeName: MaxTimeMSExpired
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            maxTimeMS: 60000
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        # In reality, the outcome of the commit is unknown but we fabricate
+        # the error with failCommand.errorCode which does not apply the commit
+        # operation.
+data: []

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/tests/commit-writeconcernerror.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/tests/commit-writeconcernerror.json
@@ -493,6 +493,110 @@
           ]
         }
       }
+    },
+    {
+      "description": "commitTransaction is not retried after MaxTimeMSExpired error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 50,
+            "codeName": "MaxTimeMSExpired",
+            "errmsg": "operation exceeded time limit"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorCodeName": "MaxTimeMSExpired",
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/tests/commit-writeconcernerror.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions-convenient-api/tests/commit-writeconcernerror.yml
@@ -193,3 +193,24 @@ tests:
     expectations: *expectations_without_retries
     # failCommand with writeConcernError still applies the write operation(s)
     outcome: *outcome
+
+  -
+    description: commitTransaction is not retried after MaxTimeMSExpired error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 50
+            codeName: MaxTimeMSExpired
+            errmsg: "operation exceeded time limit"
+    operations:
+      - <<: *operation
+        result:
+          errorCodeName: MaxTimeMSExpired
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+    expectations: *expectations_without_retries
+    # failCommand with writeConcernError still applies the write operation(s)
+outcome: *outcome

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/TransactionTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/TransactionTestRunner.cs
@@ -450,6 +450,7 @@ namespace MongoDB.Driver.Tests.Specifications.transactions
             ReadConcern readConcern = null;
             ReadPreference readPreference = null;
             WriteConcern writeConcern = null;
+            TimeSpan? maxCommitTimeMS = null;
 
             foreach (var element in document)
             {
@@ -467,12 +468,16 @@ namespace MongoDB.Driver.Tests.Specifications.transactions
                         writeConcern = WriteConcern.FromBsonDocument(element.Value.AsBsonDocument);
                         break;
 
+                    case "maxCommitTimeMS":
+                        maxCommitTimeMS = TimeSpan.FromMilliseconds(element.Value.ToInt32());
+                        break;
+
                     default:
                         throw new ArgumentException($"Invalid field: {element.Name}.");
                 }
             }
 
-            return new TransactionOptions(readConcern, readPreference, writeConcern);
+            return new TransactionOptions(readConcern, readPreference, writeConcern, maxCommitTimeMS);
         }
 
         private void VerifyCollectionOutcome(BsonDocument outcome)

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/README.rst
@@ -61,10 +61,11 @@ control the fail point's behavior. ``failCommand`` supports the following
 
 - ``failCommands``: Required, the list of command names to fail.
 - ``closeConnection``: Boolean option, which defaults to ``false``. If
-  ``true``, the connection on which the command is executed will be closed
-  and the client will see a network error.
-- ``errorCode``: Integer option, which is unset by default. If set, the
-  specified command error code will be returned as a command error.
+  ``true``, the command will not be executed, the connection will be closed, and
+  the client will see a network error.
+- ``errorCode``: Integer option, which is unset by default. If set, the command
+  will not be executed and the specified command error code will be returned as
+  a command error.
 - ``writeConcernError``: A document, which is unset by default. If set, the
   server will return this document in the "writeConcernError" field. This
   failure response only applies to commands that support write concern and

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/error-labels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/error-labels.json
@@ -1564,6 +1564,400 @@
           ]
         }
       }
+    },
+    {
+      "description": "do not add unknown commit label to MaxTimeMSExpired inside transactions",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "maxTimeMS": 60000,
+            "session": "session0"
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult",
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$project": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "cursor": {},
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "maxTimeMS": 60000
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "add unknown commit label to MaxTimeMSExpired",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxCommitTimeMS": 60000
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "add unknown commit label to writeConcernError MaxTimeMSExpired",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 50,
+            "errmsg": "operation exceeded time limit"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxCommitTimeMS": 60000
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/error-labels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/error-labels.yml
@@ -959,3 +959,247 @@ tests:
       collection:
         data:
           - _id: 1
+
+  - description: do not add unknown commit label to MaxTimeMSExpired inside transactions
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+        failCommands: ["aggregate"]
+        errorCode: 50  # MaxTimeMSExpired
+
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: aggregate
+        object: collection
+        arguments:
+          pipeline:
+            - $project:
+                _id: 1
+          maxTimeMS: 60000
+          session: session0
+        result:
+          errorLabelsOmit: ["UnknownTransactionCommitResult", "TransientTransactionError"]
+      - name: abortTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline:
+              - $project:
+                  _id: 1
+            cursor: {}
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            autocommit: false
+            maxTimeMS: 60000
+          command_name: aggregate
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data: []
+
+  - description: add unknown commit label to MaxTimeMSExpired
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 50  # MaxTimeMSExpired
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            writeConcern:
+              w: majority
+            maxCommitTimeMS: 60000
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+        result:
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+      - name: commitTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+              w: majority
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            # commitTransaction applies w:majority on retries
+            writeConcern: { w: majority, wtimeout: 10000 }
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+
+  - description: add unknown commit label to writeConcernError MaxTimeMSExpired
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 50  # MaxTimeMSExpired
+            errmsg: operation exceeded time limit
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            writeConcern:
+              w: majority
+            maxCommitTimeMS: 60000
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+        result:
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+      - name: commitTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+              w: majority
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            # commitTransaction applies w:majority on retries
+            writeConcern: { w: majority, wtimeout: 10000 }
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/transaction-options.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/transaction-options.json
@@ -81,7 +81,8 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -98,7 +99,8 @@
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -123,7 +125,8 @@
               "readConcern": {
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -140,7 +143,8 @@
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -227,7 +231,8 @@
               "readConcern": {
                 "level": "local"
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -246,7 +251,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": 1
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -272,7 +278,8 @@
                 "level": "local",
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -291,7 +298,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": 1
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -318,7 +326,8 @@
             },
             "writeConcern": {
               "w": 1
-            }
+            },
+            "maxCommitTimeMS": 60000
           }
         }
       },
@@ -405,7 +414,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": 1
-              }
+              },
+              "maxTimeMS": 60000
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -481,7 +491,8 @@
             },
             "writeConcern": {
               "w": 1
-            }
+            },
+            "maxCommitTimeMS": 30000
           }
         }
       },
@@ -496,7 +507,8 @@
               },
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxCommitTimeMS": 60000
             }
           }
         },
@@ -569,7 +581,8 @@
               "readConcern": {
                 "level": "snapshot"
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -588,7 +601,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": 60000
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -614,7 +628,8 @@
                 "level": "snapshot",
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -633,7 +648,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -664,7 +680,8 @@
             },
             "writeConcern": {
               "w": "majority"
-            }
+            },
+            "maxCommitTimeMS": 60000
           }
         }
       },
@@ -732,7 +749,8 @@
               "readConcern": {
                 "level": "snapshot"
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -751,7 +769,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": 60000
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -777,7 +796,8 @@
                 "level": "snapshot",
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -796,7 +816,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/transaction-options.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/transaction-options.yml
@@ -55,6 +55,7 @@ tests:
             autocommit: false
             readConcern:
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -67,6 +68,7 @@ tests:
             autocommit: false
             readConcern:
             writeConcern:
+            maxTimeMS:
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -83,6 +85,7 @@ tests:
             readConcern:
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -95,6 +98,7 @@ tests:
             autocommit: false
             readConcern:
             writeConcern:
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 
@@ -126,6 +130,7 @@ tests:
             readConcern:
               level: local
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -139,6 +144,7 @@ tests:
             readConcern:
             writeConcern:
               w: 1
+            maxTimeMS:
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -156,6 +162,7 @@ tests:
               level: local
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -169,6 +176,7 @@ tests:
             readConcern:
             writeConcern:
               w: 1
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 
@@ -183,6 +191,7 @@ tests:
             level: snapshot
           writeConcern:
             w: 1
+          maxCommitTimeMS: 60000
 
     operations: *commitAbortOperations
 
@@ -214,6 +223,7 @@ tests:
             readConcern:
             writeConcern:
               w: 1
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -262,6 +272,7 @@ tests:
             level: majority
           writeConcern:
             w: 1
+          maxCommitTimeMS: 30000
 
     operations:
       - name: startTransaction
@@ -272,6 +283,7 @@ tests:
               level: snapshot
             writeConcern:
               w: majority
+            maxCommitTimeMS: 60000
       - name: insertOne
         object: collection
         arguments:
@@ -316,6 +328,7 @@ tests:
             readConcern:
               level: snapshot
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -329,6 +342,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -346,6 +360,7 @@ tests:
               level: snapshot
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -359,6 +374,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 
@@ -377,6 +393,7 @@ tests:
             level: snapshot
           writeConcern:
             w: majority
+          maxCommitTimeMS: 60000
 
     operations: *commitAbortOperations
 
@@ -395,6 +412,7 @@ tests:
             readConcern:
               level: snapshot
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -408,6 +426,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -425,6 +444,7 @@ tests:
               level: snapshot
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -438,6 +458,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5d1d06492fbabe1ad8054e0c
Spec commit: https://github.com/mongodb/specifications/commit/8a2c678ff8fe9144870cec835554181dd6639fa3#diff-094aff63959e83d58ae821d4e2bf6659R413