### PR TITLE
CSHARP-2697: Fix the issue with initial host resolving for replica set.

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -225,7 +225,7 @@ functions:
         working_dir: mongo-csharp-driver
         script: |
           # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
-          ATLAS_FREE="${ATLAS_FREE}" ATLAS_REPLICA="${ATLAS_REPLICA}" ATLAS_SHARDED="${ATLAS_SHARDED}" ATLAS_TLS11="${ATLAS_TLS11}" ATLAS_TLS12="${ATLAS_TLS12}" evergreen/run-atlas-connectivity-tests.sh
+          ATLAS_FREE="${ATLAS_FREE}" ATLAS_FREE_SRV="${ATLAS_FREE_SRV}" ATLAS_REPLICA="${ATLAS_REPLICA}" ATLAS_REPLICA_SRV="${ATLAS_REPLICA_SRV}" ATLAS_SHARDED="${ATLAS_SHARDED}" ATLAS_SHARDED_SRV="${ATLAS_SHARDED_SRV}" ATLAS_TLS11="${ATLAS_TLS11}" ATLAS_TLS11_SRV="${ATLAS_TLS11_SRV}" ATLAS_TLS12="${ATLAS_TLS12}" ATLAS_TLS12_SRV="${ATLAS_TLS12_SRV}" evergreen/run-atlas-connectivity-tests.sh
 
   run-plain-auth-tests:
     - command: shell.exec

--- a/src/MongoDB.Driver.Core/Core/Clusters/DnsMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/DnsMonitor.cs
@@ -161,7 +161,7 @@ namespace MongoDB.Driver.Core.Clusters
         {
             while (true)
             {
-                if (_cluster.ShouldDnsMonitorStop())
+                if (_processDnsResultHasEverBeenCalled && _cluster.ShouldDnsMonitorStop())
                 {
                     return;
                 }

--- a/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
@@ -536,16 +536,14 @@ namespace MongoDB.Driver.Core.Clusters
                 return;
             }
 
+            // Assuming that before this method one from the following conditions has been validated:
+            // 1. The cluster type is Unknown or Sharded.
+            // 2. This method has been called the first time.
+            // Otherwise, the below code should not be called.
             var newServers = new List<IClusterableServer>();
             lock (_updateClusterDescriptionLock)
             {
                 var oldClusterDescription = Description;
-
-                var clusterType = oldClusterDescription.Type;
-                if (clusterType != ClusterType.Unknown && clusterType != ClusterType.Sharded)
-                {
-                    return;
-                }
 
                 var newClusterDescription = oldClusterDescription;
                 var currentEndPoints = oldClusterDescription.Servers.Select(serverDescription => serverDescription.EndPoint).ToList();

--- a/tests/AtlasConnectivity.Tests/ConnectivityTests.cs
+++ b/tests/AtlasConnectivity.Tests/ConnectivityTests.cs
@@ -18,7 +18,6 @@ using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.TestHelpers;
-using MongoDB.Driver.Tests;
 using Xunit;
 
 namespace AtlasConnectivity.Tests
@@ -27,10 +26,15 @@ namespace AtlasConnectivity.Tests
     {
         [Theory]
         [InlineData("ATLAS_FREE")]
+        [InlineData("ATLAS_FREE_SRV")]
         [InlineData("ATLAS_REPLICA")]
+        [InlineData("ATLAS_REPLICA_SRV")]
         [InlineData("ATLAS_SHARDED")]
+        [InlineData("ATLAS_SHARDED_SRV")]
         [InlineData("ATLAS_TLS11")]
+        [InlineData("ATLAS_TLS11_SRV")]
         [InlineData("ATLAS_TLS12")]
+        [InlineData("ATLAS_TLS12_SRV")]
         public void Connection_to_Atlas_should_work(string environmentVariableName)
         {
             var connectionString = Environment.GetEnvironmentVariable(environmentVariableName);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
@@ -20,7 +20,6 @@ using System.Net;
 using System.Threading;
 using FluentAssertions;
 using MongoDB.Bson.TestHelpers;
-using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Misc;
@@ -29,8 +28,6 @@ using MongoDB.Driver.Core.Helpers;
 using Moq;
 using Xunit;
 using MongoDB.Bson;
-using System.Reflection;
-using MongoDB.Driver.Core.Async;
 using MongoDB.Driver.Core.Tests.Core.Clusters;
 using System.Threading.Tasks;
 
@@ -446,30 +443,6 @@ namespace MongoDB.Driver.Core.Clusters
                 var originalDescription = subject.Description;
 
                 PublishDnsResults(subject, endPoints);
-
-                subject.Description.Should().BeSameAs(originalDescription);
-            }
-        }
-
-        [Theory]
-        [InlineData(ServerType.Standalone, ServerType.Standalone, ClusterType.Standalone)]
-        [InlineData(ServerType.ReplicaSetPrimary, ServerType.ReplicaSetSecondary, ClusterType.ReplicaSet)]
-        public void ProcessDnsResults_should_do_nothing_if_cluster_type_is_not_unknown_or_sharded(ServerType serverType1, ServerType serverType2, ClusterType clusterType)
-        {
-            var settings = new ClusterSettings(scheme: ConnectionStringScheme.MongoDBPlusSrv, endPoints: new[] { new DnsEndPoint("a.b.com", 53) });
-            var mockDnsMonitorFactory = CreateMockDnsMonitorFactory();
-            using (var subject = CreateSubject(settings: settings, dnsMonitorFactory: mockDnsMonitorFactory.Object))
-            {
-                subject.Initialize();
-                PublishDnsResults(subject, _firstEndPoint);
-                PublishDescription(subject, _firstEndPoint, serverType1);
-                subject.Description.Type.Should().Be(clusterType);
-                var expectedEndPoints = clusterType == ClusterType.Standalone ? new[] { _firstEndPoint } : new[] { _firstEndPoint, _secondEndPoint, _thirdEndPoint };
-                subject.Description.Servers.Select(s => s.EndPoint).Should().Equal(expectedEndPoints);
-                var originalDescription = subject.Description;
-                var endPointThatShouldBeIgnored = new DnsEndPoint("localhost", 27020);
-
-                PublishDnsResults(subject, endPointThatShouldBeIgnored);
 
                 subject.Description.Should().BeSameAs(originalDescription);
             }


### PR DESCRIPTION
CSHARP-2697: Fix the issue with initial host resolving for replica set.

CSHARP-2642: Add srv connection strings to atlas connectivity tests.

Evergreen: https://evergreen.mongodb.com/version/5d5c178e9ccd4e79cfd2a4cc