### PR TITLE
2672: Snappy compression doesn't work 

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -483,12 +483,12 @@ buildvariants:
   tasks:
      - name: "test"
 
-#- matrix_name: "tests-snappy-compression"
-#  matrix_spec: { compressor : "snappy", auth: "noauth", ssl: "nossl", version: ["3.4", "3.6", "4.0", "4.2", "latest"], topology: "standalone", os: "*" }
-#  display_name: "${version} ${compressor} ${topology} ${auth} ${ssl} ${os} "
-#  tags: ["tests-variant"]
-#  tasks:
-#     - name: "test"
+- matrix_name: "tests-snappy-compression"
+  matrix_spec: { compressor : "snappy", auth: "noauth", ssl: "nossl", version: ["3.4", "3.6", "4.0", "4.2", "latest"], topology: "standalone", os: "*" }
+  display_name: "${version} ${compressor} ${topology} ${auth} ${ssl} ${os} "
+  tags: ["tests-variant"]
+  tasks:
+     - name: "test"
 
 - name: atlas-connectivity-tests
   display_name: "Atlas Connectivity Tests"

--- a/tests/MongoDB.Driver.Core.Tests/Core/Compression/CompressorsTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Compression/CompressorsTests.cs
@@ -14,7 +14,9 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using FluentAssertions;
 using MongoDB.Bson.IO;
@@ -29,6 +31,91 @@ namespace MongoDB.Driver.Core.Tests.Core.Compression
     public class CompressorsTests
     {
         private static string __testMessage = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
+
+        [Theory]
+        [InlineData(CompressorType.Snappy)]
+        public void Compressor_should_read_the_previously_written_big_message_or_throw_the_exception_if_the_current_platform_is_not_supported(CompressorType compressorType)
+        {
+            var message = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
+
+            var compressedMessage = "158;2;100;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;254;26;0;254;26;0;254;26;0;254;26;0;1;26";
+            var decompressedMessage = "97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122;97;98;99;100;101;102;103;104;105;106;107;108;109;110;111;112;113;114;115;116;117;118;119;120;121;122";
+
+            string TestCase(string incomeMessage, string expectedCompressed, string expectedDecompressed)
+            {
+                var bytes = Encoding.ASCII.GetBytes(incomeMessage);
+                var compressor = GetCompressor(compressorType);
+
+                var inputStream = GetStreamFromBytes(bytes);
+                var outpustStream = GetStreamFromBytes();
+
+                compressor.Compress(inputStream, outpustStream);
+
+                var compressed = GetBytesFromStream(outpustStream);
+                var compressedStr = string.Join(";", compressed);
+                compressedStr.Should().Be(expectedCompressed);
+
+                var compressedBytes = GetBytesFromStream(outpustStream);
+                var list = new List<byte>();
+                list.AddRange(new byte[]
+                {
+                    // Filled here: https://github.com/robertvazan/snappy.net/blob/master/Snappy.NET/SnappyFrame.cs#L342
+                    255, 6, 0, 0,   // `255` - shows the type for next header section. 255 - `StreamIdentifier`, the next 6 bytes will parsed as `StreamIdentifier` header.
+                    // Contains `ASCII` bytes from `sNaPpY` string. So, it's constant bytes.
+                    //https://github.com/robertvazan/snappy.net/blob/master/Snappy.NET/SnappyFrame.cs#L26
+                    115, 78, 97, 80, 112, 89, // contant bytes
+                    // NOTE: the above header bytes are constants!!
+
+
+
+                    // Contains information about compressed data
+                    // show the type of data after the headers. `0` - Compressed: https://github.com/robertvazan/snappy.net/blob/master/Snappy.NET/SnappyFrameType.cs#L16.
+                    // It means that next block(after the checksum header) will be tried to be decompressed.
+                    // `47` - the size of all content after the current header. Which includes a `checksum` header + compressed data.
+                    0, 47, 0, 0,  // so the full size of compressed data is `43` (47 - 4)
+
+                    33, 133, 232, 85 // The checkSum header. Calculated here: https://github.com/robertvazan/snappy.net/blob/master/Snappy.NET/SnappyFrame.cs#L493
+                });
+                list.AddRange(compressedBytes.ToList());
+                compressedBytes = list.ToArray();
+                var outStream = GetStreamFromBytes(compressedBytes);
+                var decStream = GetStreamFromBytes();
+                outpustStream.Position = 0;
+                compressor.Decompress(outStream, decStream);
+                var decompressed = GetBytesFromStream(decStream);
+                var decompressedStr = string.Join(";", decompressed);
+                decompressedStr.Should().Be(expectedDecompressed);
+                List<byte> resultBytes = new List<byte>();
+                resultBytes.AddRange(decompressed);
+                return Encoding.ASCII.GetString(resultBytes.ToArray());
+            }
+
+#if NET452 || NETSTANDARD2_0
+            TestCase(message, compressedMessage, decompressedMessage)
+                .Should().Be(message);
+#else
+            Record.Exception(() => TestCase(message, compressedMessage, decompressedMessage))
+                .Should().BeOfType<NotSupportedException>();
+#endif
+        }
+
+        private Stream GetStreamFromBytes(byte[] bytes = null)
+        {
+            return bytes != null ? new MemoryStream(bytes) : new MemoryStream();
+        }
+
+        private byte[] GetBytesFromStream(Stream str)
+        {
+            str.Position = 0;
+            if (str is MemoryStream ms)
+            {
+                return ms.ToArray();
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
 
         [Theory]
         [InlineData(CompressorType.Snappy)]


### PR DESCRIPTION
So, I made a small investigation of snappy and CSHARP-2672.
The problem is related to the fact that a server expects only compressed data, but the way, which we currently use, sends snappy `headers + data`.

Originally, when I implemented this ticket, I used the way which worked exactly with bytes array (without snappy headers) like this:

Compress:

    var maxSize = SnappyCodec.GetMaxCompressedLength(inputBytes.Length);
    byte[] result = new byte[maxSize];
    var realSize = SnappyCodec.Compress(inputBytes, offset, inputBytes.Length - offset, result, 0);
    var compressedBytes = realSize != maxSize ? result.Take(realSize).ToArray() : result;

Decompress:

    var resBytes = SnappyCodec.Uncompress(inputBytes);
    var decompressedBytes = SnappyCodec.Uncompress(inputBytes);

This way still works, but then we decided that the way based on working with streams itself is better by performance reasons.
Currently, it's implemented in this way:
https://github.com/mongodb/mongo-csharp-driver/blob/master/src/MongoDB.Driver.Core/Core/Compression/SnappyCompressor.cs#L33
where we copy compressed/decompressed data from `snappy` stream into the output stream without any additional steps.

And this way works fine from the driver point of view, all tests pass since we are checking whether compressed data can be decompressed into the original form or not. But we don't test this logic with a server. The way which had to do it via a new task on evergreen, probably is configured incorrectly.

That's why we didn't notice that the format of compressed data has been changed(in some code review step) and the server cannot process compressed requests even though we still can compress and then decompress any data in our local tests.

In this PR, I've added a new test which shows the problem.

cc: @jyemin, @vincentkam, @rstam 