### PR TITLE
CSHARP-2065: Support ReplaceOptions in CRUD API.

### DIFF
--- a/src/MongoDB.Driver/IMongoCollection.cs
+++ b/src/MongoDB.Driver/IMongoCollection.cs
@@ -723,7 +723,7 @@ namespace MongoDB.Driver
         /// <param name="document">The document.</param>
         /// <param name="options">The options.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        void InsertOne( IClientSessionHandle session, TDocument document, InsertOneOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
+        void InsertOne(IClientSessionHandle session, TDocument document, InsertOneOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Inserts a single document.
@@ -867,7 +867,21 @@ namespace MongoDB.Driver
         /// <returns>
         /// The result of the replacement.
         /// </returns>
-        ReplaceOneResult ReplaceOne(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
+        ReplaceOneResult ReplaceOne(FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
+
+
+        /// <summary>
+        /// Replaces a single document.
+        /// </summary>
+        /// <param name="filter">The filter.</param>
+        /// <param name="replacement">The replacement.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The result of the replacement.
+        /// </returns>
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        ReplaceOneResult ReplaceOne(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Replaces a single document.
@@ -880,19 +894,7 @@ namespace MongoDB.Driver
         /// <returns>
         /// The result of the replacement.
         /// </returns>
-        ReplaceOneResult ReplaceOne(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Replaces a single document.
-        /// </summary>
-        /// <param name="filter">The filter.</param>
-        /// <param name="replacement">The replacement.</param>
-        /// <param name="options">The options.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>
-        /// The result of the replacement.
-        /// </returns>
-        Task<ReplaceOneResult> ReplaceOneAsync(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
+        ReplaceOneResult ReplaceOne(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Replaces a single document.
@@ -905,7 +907,60 @@ namespace MongoDB.Driver
         /// <returns>
         /// The result of the replacement.
         /// </returns>
-        Task<ReplaceOneResult> ReplaceOneAsync(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        ReplaceOneResult ReplaceOne(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Replaces a single document.
+        /// </summary>
+        /// <param name="filter">The filter.</param>
+        /// <param name="replacement">The replacement.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The result of the replacement.
+        /// </returns>
+        Task<ReplaceOneResult> ReplaceOneAsync(FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Replaces a single document.
+        /// </summary>
+        /// <param name="filter">The filter.</param>
+        /// <param name="replacement">The replacement.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The result of the replacement.
+        /// </returns>
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        Task<ReplaceOneResult> ReplaceOneAsync(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Replaces a single document.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="replacement">The replacement.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The result of the replacement.
+        /// </returns>
+        Task<ReplaceOneResult> ReplaceOneAsync(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Replaces a single document.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="replacement">The replacement.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The result of the replacement.
+        /// </returns>
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        Task<ReplaceOneResult> ReplaceOneAsync(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Updates many documents.

--- a/src/MongoDB.Driver/IMongoCollectionExtensions.cs
+++ b/src/MongoDB.Driver/IMongoCollectionExtensions.cs
@@ -71,7 +71,7 @@ namespace MongoDB.Driver
         public static IMongoQueryable<TDocument> AsQueryable<TDocument>(this IMongoCollection<TDocument> collection, AggregateOptions aggregateOptions = null)
         {
             Ensure.IsNotNull(collection, nameof(collection));
-            
+
             aggregateOptions = aggregateOptions ?? new AggregateOptions();
             var provider = new MongoQueryProviderImpl<TDocument>(collection, aggregateOptions);
             return new MongoQueryableImpl<TDocument, TDocument>(provider);
@@ -1856,12 +1856,35 @@ namespace MongoDB.Driver
         /// <returns>
         /// The result of the replacement.
         /// </returns>
-        public static ReplaceOneResult ReplaceOne<TDocument>(this IMongoCollection<TDocument> collection, Expression<Func<TDocument, bool>> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static ReplaceOneResult ReplaceOne<TDocument>(this IMongoCollection<TDocument> collection, Expression<Func<TDocument, bool>> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.IsNotNull(collection, nameof(collection));
             Ensure.IsNotNull(filter, nameof(filter));
 
             return collection.ReplaceOne(new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
+        }
+
+        /// <summary>
+        /// Replaces a single document.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the document.</typeparam>
+        /// <param name="collection">The collection.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="replacement">The replacement.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The result of the replacement.
+        /// </returns>
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        public static ReplaceOneResult ReplaceOne<TDocument>(this IMongoCollection<TDocument> collection, Expression<Func<TDocument, bool>> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Ensure.IsNotNull(collection, nameof(collection));
+            Ensure.IsNotNull(filter, nameof(filter));
+
+#pragma warning disable 618
+            return collection.ReplaceOne(new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -1877,7 +1900,7 @@ namespace MongoDB.Driver
         /// <returns>
         /// The result of the replacement.
         /// </returns>
-        public static ReplaceOneResult ReplaceOne<TDocument>(this IMongoCollection<TDocument> collection, IClientSessionHandle session, Expression<Func<TDocument, bool>> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static ReplaceOneResult ReplaceOne<TDocument>(this IMongoCollection<TDocument> collection, IClientSessionHandle session, Expression<Func<TDocument, bool>> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.IsNotNull(collection, nameof(collection));
             Ensure.IsNotNull(session, nameof(session));
@@ -1891,6 +1914,7 @@ namespace MongoDB.Driver
         /// </summary>
         /// <typeparam name="TDocument">The type of the document.</typeparam>
         /// <param name="collection">The collection.</param>
+        /// <param name="session">The session.</param>
         /// <param name="filter">The filter.</param>
         /// <param name="replacement">The replacement.</param>
         /// <param name="options">The options.</param>
@@ -1898,12 +1922,59 @@ namespace MongoDB.Driver
         /// <returns>
         /// The result of the replacement.
         /// </returns>
-        public static Task<ReplaceOneResult> ReplaceOneAsync<TDocument>(this IMongoCollection<TDocument> collection, Expression<Func<TDocument, bool>> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        public static ReplaceOneResult ReplaceOne<TDocument>(this IMongoCollection<TDocument> collection, IClientSessionHandle session, Expression<Func<TDocument, bool>> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Ensure.IsNotNull(collection, nameof(collection));
+            Ensure.IsNotNull(session, nameof(session));
+            Ensure.IsNotNull(filter, nameof(filter));
+
+#pragma warning disable 618
+            return collection.ReplaceOne(session, new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
+#pragma warning restore 618
+        }
+
+        /// <summary>
+        /// Replaces a single document.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the document.</typeparam>
+        /// <param name="collection">The collection.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="replacement">The replacement.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The result of the replacement.
+        /// </returns>
+        public static Task<ReplaceOneResult> ReplaceOneAsync<TDocument>(this IMongoCollection<TDocument> collection, Expression<Func<TDocument, bool>> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.IsNotNull(collection, nameof(collection));
             Ensure.IsNotNull(filter, nameof(filter));
 
             return collection.ReplaceOneAsync(new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
+        }
+
+        /// <summary>
+        /// Replaces a single document.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the document.</typeparam>
+        /// <param name="collection">The collection.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="replacement">The replacement.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The result of the replacement.
+        /// </returns>
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        public static Task<ReplaceOneResult> ReplaceOneAsync<TDocument>(this IMongoCollection<TDocument> collection, Expression<Func<TDocument, bool>> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Ensure.IsNotNull(collection, nameof(collection));
+            Ensure.IsNotNull(filter, nameof(filter));
+
+#pragma warning disable 618
+            return collection.ReplaceOneAsync(new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -1919,13 +1990,38 @@ namespace MongoDB.Driver
         /// <returns>
         /// The result of the replacement.
         /// </returns>
-        public static Task<ReplaceOneResult> ReplaceOneAsync<TDocument>(this IMongoCollection<TDocument> collection, IClientSessionHandle session, Expression<Func<TDocument, bool>> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task<ReplaceOneResult> ReplaceOneAsync<TDocument>(this IMongoCollection<TDocument> collection, IClientSessionHandle session, Expression<Func<TDocument, bool>> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.IsNotNull(collection, nameof(collection));
             Ensure.IsNotNull(session, nameof(session));
             Ensure.IsNotNull(filter, nameof(filter));
 
             return collection.ReplaceOneAsync(session, new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
+        }
+
+        /// <summary>
+        /// Replaces a single document.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the document.</typeparam>
+        /// <param name="collection">The collection.</param>
+        /// <param name="session">The session.</param>
+        /// <param name="filter">The filter.</param>
+        /// <param name="replacement">The replacement.</param>
+        /// <param name="options">The options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>
+        /// The result of the replacement.
+        /// </returns>
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        public static Task<ReplaceOneResult> ReplaceOneAsync<TDocument>(this IMongoCollection<TDocument> collection, IClientSessionHandle session, Expression<Func<TDocument, bool>> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Ensure.IsNotNull(collection, nameof(collection));
+            Ensure.IsNotNull(session, nameof(session));
+            Ensure.IsNotNull(filter, nameof(filter));
+
+#pragma warning disable 618
+            return collection.ReplaceOneAsync(session, new ExpressionFilterDefinition<TDocument>(filter), replacement, options, cancellationToken);
+#pragma warning restore 618
         }
 
         /// <summary>

--- a/src/MongoDB.Driver/MongoCollectionBase.cs
+++ b/src/MongoDB.Driver/MongoCollectionBase.cs
@@ -21,8 +21,6 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver.Core.Misc;
-using MongoDB.Driver.Core.Operations;
-using MongoDB.Driver.Linq;
 
 namespace MongoDB.Driver
 {
@@ -553,27 +551,38 @@ namespace MongoDB.Driver
         public abstract IFilteredMongoCollection<TDerivedDocument> OfType<TDerivedDocument>() where TDerivedDocument : TDocument;
 
         /// <inheritdoc />
-        public virtual ReplaceOneResult ReplaceOne(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        public ReplaceOneResult ReplaceOne(FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return ReplaceOne(filter, replacement, options, (requests, bulkWriteOptions) => BulkWrite(requests, bulkWriteOptions, cancellationToken));
         }
 
         /// <inheritdoc />
-        public virtual ReplaceOneResult ReplaceOne(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        public virtual ReplaceOneResult ReplaceOne(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return ReplaceOne(filter, replacement, ReplaceOptions.From(options), (requests, bulkWriteOptions) => BulkWrite(requests, bulkWriteOptions, cancellationToken));
+        }
+
+
+        /// <inheritdoc />
+        public ReplaceOneResult ReplaceOne(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return ReplaceOne(filter, replacement, options, (requests, bulkWriteOptions) => BulkWrite(session, requests, bulkWriteOptions, cancellationToken));
         }
 
-        private ReplaceOneResult ReplaceOne(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, Func<IEnumerable<WriteModel<TDocument>>, BulkWriteOptions, BulkWriteResult<TDocument>> bulkWrite)
+        /// <inheritdoc />
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        public virtual ReplaceOneResult ReplaceOne(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return ReplaceOne(filter, replacement, ReplaceOptions.From(options), (requests, bulkWriteOptions) => BulkWrite(session, requests, bulkWriteOptions, cancellationToken));
+        }
+
+        private ReplaceOneResult ReplaceOne(FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options, Func<IEnumerable<WriteModel<TDocument>>, BulkWriteOptions, BulkWriteResult<TDocument>> bulkWrite)
         {
             Ensure.IsNotNull(filter, nameof(filter));
             Ensure.IsNotNull((object)replacement, "replacement");
-            if (options?.ArrayFilters != null)
-            {
-                throw new ArgumentException("ArrayFilters cannot be used with ReplaceOne.", nameof(options));
-            }
 
-            options = options ?? new UpdateOptions();
+            options = options ?? new ReplaceOptions();
             var model = new ReplaceOneModel<TDocument>(filter, replacement)
             {
                 Collation = options.Collation,
@@ -596,27 +605,37 @@ namespace MongoDB.Driver
         }
 
         /// <inheritdoc />
-        public virtual Task<ReplaceOneResult> ReplaceOneAsync(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<ReplaceOneResult> ReplaceOneAsync(FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return ReplaceOneAsync(filter, replacement, options, (requests, bulkWriteOptions) => BulkWriteAsync(requests, bulkWriteOptions, cancellationToken));
         }
 
         /// <inheritdoc />
-        public virtual Task<ReplaceOneResult> ReplaceOneAsync(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        public virtual Task<ReplaceOneResult> ReplaceOneAsync(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return ReplaceOneAsync(filter, replacement, ReplaceOptions.From(options), (requests, bulkWriteOptions) => BulkWriteAsync(requests, bulkWriteOptions, cancellationToken));
+        }
+
+        /// <inheritdoc />
+        public Task<ReplaceOneResult> ReplaceOneAsync(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return ReplaceOneAsync(filter, replacement, options, (requests, bulkWriteOptions) => BulkWriteAsync(session, requests, bulkWriteOptions, cancellationToken));
         }
 
-        private async Task<ReplaceOneResult> ReplaceOneAsync(FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, Func<IEnumerable<WriteModel<TDocument>>, BulkWriteOptions, Task<BulkWriteResult<TDocument>>> bulkWriteAsync)
+        /// <inheritdoc />
+        [Obsolete("Use the overload that takes a ReplaceOptions instead of an UpdateOptions.")]
+        public virtual Task<ReplaceOneResult> ReplaceOneAsync(IClientSessionHandle session, FilterDefinition<TDocument> filter, TDocument replacement, UpdateOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return ReplaceOneAsync(filter, replacement, ReplaceOptions.From(options), (requests, bulkWriteOptions) => BulkWriteAsync(session, requests, bulkWriteOptions, cancellationToken));
+        }
+
+        private async Task<ReplaceOneResult> ReplaceOneAsync(FilterDefinition<TDocument> filter, TDocument replacement, ReplaceOptions options, Func<IEnumerable<WriteModel<TDocument>>, BulkWriteOptions, Task<BulkWriteResult<TDocument>>> bulkWriteAsync)
         {
             Ensure.IsNotNull(filter, nameof(filter));
             Ensure.IsNotNull((object)replacement, "replacement");
-            if (options?.ArrayFilters != null)
-            {
-                throw new ArgumentException("ArrayFilters cannot be used with ReplaceOne.", nameof(options));
-            }
 
-            options = options ?? new UpdateOptions();
+            options = options ?? new ReplaceOptions();
             var model = new ReplaceOneModel<TDocument>(filter, replacement)
             {
                 Collation = options.Collation,

--- a/src/MongoDB.Driver/ReplaceOptions.cs
+++ b/src/MongoDB.Driver/ReplaceOptions.cs
@@ -1,0 +1,88 @@
+﻿/* Copyright 2019-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace MongoDB.Driver
+{
+    /// <summary>
+    /// Options for replacing a single document.
+    /// </summary>
+    public sealed class ReplaceOptions
+    {
+        #region static
+        // public static methods
+        /// <summary>
+        /// Creates a new ReplaceOptions from an UpdateOptions.
+        /// </summary>
+        /// <param name="updateOptions">The update options.</param>
+        /// <returns>A ReplaceOptions.</returns>
+        internal static ReplaceOptions From(UpdateOptions updateOptions)
+        {
+            if (updateOptions == null)
+            {
+                return null;
+            }
+            else
+            {
+                if (updateOptions.ArrayFilters != null)
+                {
+                    throw new ArgumentException("ArrayFilters cannot be used with ReplaceOne.", nameof(updateOptions));
+                }
+
+                return new ReplaceOptions
+                {
+                    BypassDocumentValidation = updateOptions.BypassDocumentValidation,
+                    Collation = updateOptions.Collation,
+                    IsUpsert = updateOptions.IsUpsert
+                };
+            }
+        }
+        #endregion
+
+        // fields
+        private bool? _bypassDocumentValidation;
+        private Collation _collation;
+        private bool _isUpsert;
+
+        // properties
+        /// <summary>
+        /// Gets or sets a value indicating whether to bypass document validation.
+        /// </summary>
+        public bool? BypassDocumentValidation
+        {
+            get { return _bypassDocumentValidation; }
+            set { _bypassDocumentValidation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the collation.
+        /// </summary>
+        public Collation Collation
+        {
+            get { return _collation; }
+            set { _collation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to insert the document if it doesn't already exist.
+        /// </summary>
+        public bool IsUpsert
+        {
+            get { return _isUpsert; }
+            set { _isUpsert = value; }
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/IMongoCollectionExtensionsTests.cs
+++ b/tests/MongoDB.Driver.Tests/IMongoCollectionExtensionsTests.cs
@@ -952,33 +952,111 @@ namespace MongoDB.Driver.Tests
             var session = new Mock<IClientSessionHandle>().Object;
             var filterExpression = (Expression<Func<Person, bool>>)(x => x.FirstName == "Jack");
             var replacement = new Person();
-            var options = new UpdateOptions();
             var cancellationToken = new CancellationTokenSource().Token;
 
-            if (usingSession)
+            assertReplaceOne();
+
+            var replaceOptions = new ReplaceOptions();
+            assertReplaceOneWithReplaceOptions(replaceOptions);
+
+            var updateOptions = new UpdateOptions();
+            assertReplaceOneWithUpdateOptions(updateOptions);
+
+            void assertReplaceOne()
             {
-                if (async)
+                if (usingSession)
                 {
-                    IMongoCollectionExtensions.ReplaceOneAsync(collection, session, filterExpression, replacement, options, cancellationToken);
-                    mockCollection.Verify(m => m.ReplaceOneAsync(session, It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+                    if (async)
+                    {
+                        IMongoCollectionExtensions.ReplaceOneAsync(collection, session, filterExpression, replacement, cancellationToken: cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOneAsync(session, It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, (ReplaceOptions)null, cancellationToken), Times.Once);
+                    }
+                    else
+                    {
+                        IMongoCollectionExtensions.ReplaceOne(collection, session, filterExpression, replacement, cancellationToken: cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOne(session, It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, (ReplaceOptions)null, cancellationToken), Times.Once);
+                    }
                 }
                 else
                 {
-                    IMongoCollectionExtensions.ReplaceOne(collection, session, filterExpression, replacement, options, cancellationToken);
-                    mockCollection.Verify(m => m.ReplaceOne(session, It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+                    if (async)
+                    {
+                        IMongoCollectionExtensions.ReplaceOneAsync(collection, filterExpression, replacement, cancellationToken: cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOneAsync(It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, (ReplaceOptions)null, cancellationToken), Times.Once);
+                    }
+                    else
+                    {
+                        IMongoCollectionExtensions.ReplaceOne(collection, filterExpression, replacement, cancellationToken: cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOne(It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, (ReplaceOptions)null, cancellationToken), Times.Once);
+                    }
                 }
             }
-            else
+
+            void assertReplaceOneWithReplaceOptions(ReplaceOptions options)
             {
-                if (async)
+                if (usingSession)
                 {
-                    IMongoCollectionExtensions.ReplaceOneAsync(collection, filterExpression, replacement, options, cancellationToken);
-                    mockCollection.Verify(m => m.ReplaceOneAsync(It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+                    if (async)
+                    {
+                        IMongoCollectionExtensions.ReplaceOneAsync(collection, session, filterExpression, replacement, options, cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOneAsync(session, It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+                    }
+                    else
+                    {
+                        IMongoCollectionExtensions.ReplaceOne(collection, session, filterExpression, replacement, options, cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOne(session, It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+                    }
                 }
                 else
                 {
-                    IMongoCollectionExtensions.ReplaceOne(collection, filterExpression, replacement, options, cancellationToken);
-                    mockCollection.Verify(m => m.ReplaceOne(It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+                    if (async)
+                    {
+                        IMongoCollectionExtensions.ReplaceOneAsync(collection, filterExpression, replacement, options, cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOneAsync(It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+                    }
+                    else
+                    {
+                        IMongoCollectionExtensions.ReplaceOne(collection, filterExpression, replacement, options, cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOne(It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+                    }
+                }
+            }
+
+            void assertReplaceOneWithUpdateOptions(UpdateOptions options)
+            {
+                if (usingSession)
+                {
+                    if (async)
+                    {
+#pragma warning disable 618
+                        IMongoCollectionExtensions.ReplaceOneAsync(collection, session, filterExpression, replacement, options, cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOneAsync(session, It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+#pragma warning restore 618
+                    }
+                    else
+                    {
+#pragma warning disable 618
+                        IMongoCollectionExtensions.ReplaceOne(collection, session, filterExpression, replacement, options, cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOne(session, It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+#pragma warning restore 618
+                    }
+                }
+                else
+                {
+                    if (async)
+                    {
+#pragma warning disable 618
+                        IMongoCollectionExtensions.ReplaceOneAsync(collection, filterExpression, replacement, options, cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOneAsync(It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+#pragma warning restore 618
+                    }
+                    else
+                    {
+#pragma warning disable 618
+                        IMongoCollectionExtensions.ReplaceOne(collection, filterExpression, replacement, options, cancellationToken);
+                        mockCollection.Verify(m => m.ReplaceOne(It.IsAny<ExpressionFilterDefinition<Person>>(), replacement, options, cancellationToken), Times.Once);
+#pragma warning restore 618
+                    }
                 }
             }
         }

--- a/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenReplaceOneTest.cs
+++ b/tests/MongoDB.Driver.Tests/JsonDrivenTests/JsonDrivenReplaceOneTest.cs
@@ -27,7 +27,7 @@ namespace MongoDB.Driver.Tests.JsonDrivenTests
     {
         // private fields
         private FilterDefinition<BsonDocument> _filter;
-        private UpdateOptions _options = new UpdateOptions();
+        private ReplaceOptions _options = new ReplaceOptions();
         private BsonDocument _replacement;
         private ReplaceOneResult _result;
         private IClientSessionHandle _session;

--- a/tests/MongoDB.Driver.Tests/Specifications/crud/ReplaceOneTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/crud/ReplaceOneTest.cs
@@ -14,7 +14,6 @@
 */
 
 using System.Linq;
-using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Misc;
@@ -25,7 +24,7 @@ namespace MongoDB.Driver.Tests.Specifications.crud
     {
         private BsonDocument _filter;
         private BsonDocument _replacement;
-        private UpdateOptions _options = new UpdateOptions();
+        private ReplaceOptions _options = new ReplaceOptions();
 
         protected override bool TrySetArgument(string name, BsonValue value)
         {


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5d8e1b9cc9ec446ba3a11877

In the current implementation we will have ambiguous method definitions only if a user specifies explicit `null` instead of `options` parameter like this: 
```
collection.ReplaceOne(filter, replacement, null)
```
NOTE: `java` has exactly the same behavior.

Not sure that it's a really often case since in the previous implementation a user didn't need to set `null` explicitly (before we had optional parameter here like `UpdateOptions options = null`). I expect that setting `null` explicitly could be done only due to carelessness.

Test Cases (Below, only commented out lines are ambiguous ):
```
            var filter = new BsonDocument();
            var replacement = new BsonDocument();
            var opt1 = collection.ReplaceOne(filter, replacement, CancellationToken.None);
            var opt2 = collection.ReplaceOne(filter, replacement, new ReplaceOptions(), CancellationToken.None);
#pragma warning disable 618
            var opt3 = collection.ReplaceOne(filter, replacement, new UpdateOptions(), CancellationToken.None);
#pragma warning restore 618
            //var opt4 = collection.ReplaceOne(filter, replacement, null);

            var opt5 = collection.ReplaceOne((IClientSessionHandle)null, filter, replacement, CancellationToken.None);
            var opt6 = collection.ReplaceOne((IClientSessionHandle)null, filter, replacement, new ReplaceOptions(), CancellationToken.None);
#pragma warning disable 618
            var opt7 = collection.ReplaceOne((IClientSessionHandle)null, filter, replacement, new UpdateOptions(), CancellationToken.None);
#pragma warning restore 618
            //var opt8 = collection.ReplaceOne((IClientSessionHandle)null, filter, replacement, null);

            var opt9 = collection.ReplaceOneAsync(filter, replacement, CancellationToken.None);
            var opt10 = collection.ReplaceOneAsync(filter, replacement, new ReplaceOptions(), CancellationToken.None);
#pragma warning disable 618
            var opt11 = collection.ReplaceOneAsync(filter, replacement, new UpdateOptions(), CancellationToken.None);
#pragma warning restore 618
            //var opt12 = collection.ReplaceOneAsync(filter, replacement, null);

            var opt13 = collection.ReplaceOneAsync((IClientSessionHandle)null, filter, replacement, CancellationToken.None);
            var opt14 = collection.ReplaceOneAsync((IClientSessionHandle)null, filter, replacement, new ReplaceOptions(), CancellationToken.None);
#pragma warning disable 618
            var opt15 = collection.ReplaceOneAsync((IClientSessionHandle)null, filter, replacement, new UpdateOptions(), CancellationToken.None);
#pragma warning restore 618
            //var opt16 = collection.ReplaceOneAsync((IClientSessionHandle)null, filter, replacement, null);

            //extensions
            var filterExpr = new ExpressionFilterDefinition<BsonDocument>(document => true);
            var optExt1 = collection.ReplaceOne(filterExpr, replacement, CancellationToken.None);
            var optExt2 = collection.ReplaceOne(filterExpr, replacement, new ReplaceOptions(), CancellationToken.None);
#pragma warning disable 618
            var optExt3 = collection.ReplaceOne(filterExpr, replacement, new UpdateOptions(), CancellationToken.None);
#pragma warning restore 618
            //var optExt4 = collection.ReplaceOne(filterExpr, replacement, null);

            var optExt5 = collection.ReplaceOne((IClientSessionHandle)null, filterExpr, replacement, CancellationToken.None);
            var optExt6 = collection.ReplaceOne((IClientSessionHandle)null, filterExpr, replacement, new ReplaceOptions(), CancellationToken.None);
#pragma warning disable 618
            var optExt7 = collection.ReplaceOne((IClientSessionHandle)null, filterExpr, replacement, new UpdateOptions(), CancellationToken.None);
#pragma warning restore 618
            //var optExt8 = collection.ReplaceOne((IClientSessionHandle)null, filterExpr, replacement, null);

            var optExt9 = collection.ReplaceOneAsync(filterExpr, replacement, CancellationToken.None);
            var optExt10 = collection.ReplaceOneAsync(filterExpr, replacement, new ReplaceOptions(), CancellationToken.None);
#pragma warning disable 618
            var optExt11 = collection.ReplaceOneAsync(filterExpr, replacement, new UpdateOptions(), CancellationToken.None);
#pragma warning restore 618
            //var optExt12 = collection.ReplaceOneAsync(filterExpr, replacement, null);

            var optExt13 = collection.ReplaceOneAsync((IClientSessionHandle)null, filterExpr, replacement, CancellationToken.None);
            var optExt14 = collection.ReplaceOneAsync((IClientSessionHandle)null, filterExpr, replacement, new ReplaceOptions(), CancellationToken.None);
#pragma warning disable 618
            var optExt15 = collection.ReplaceOneAsync((IClientSessionHandle)null, filterExpr, replacement, new UpdateOptions(), CancellationToken.None);
#pragma warning restore 618
            //var optExt16 = collection.ReplaceOneAsync((IClientSessionHandle)null, filterExpr, replacement, null);
```