### PR TITLE
CSHARP-2092: Cursor iteration should complete (abnormally) when another thread closes the cursor.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -75,6 +75,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __scramSha256Authentication = new Feature("ScramSha256Authentication", new SemanticVersion(4, 0, 0, ""));
         private static readonly Feature __serverExtractsUsernameFromX509Certificate = new Feature("ServerExtractsUsernameFromX509Certificate", new SemanticVersion(3, 3, 12));
         private static readonly Feature __shardedTransactions = new Feature("ShardedTransactions", new SemanticVersion(4, 1, 6));
+        private static readonly Feature __tailableCursor = new Feature("TailableCursor", new SemanticVersion(3, 2, 0));
         private static readonly Feature __transactions = new Feature("Transactions", new SemanticVersion(4, 0, 0));
         private static readonly Feature __userManagementCommands = new Feature("UserManagementCommands", new SemanticVersion(2, 6, 0));
         private static readonly Feature __views = new Feature("Views", new SemanticVersion(3, 3, 11));
@@ -340,6 +341,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the sharded transactions feature.
         /// </summary>
         public static Feature ShardedTransactions => __shardedTransactions;
+
+        /// <summary>
+        /// Gets the tailable cursor feature.
+        /// </summary>
+        public static Feature TailableCursor => __tailableCursor;
 
         /// <summary>
         /// Gets the transactions feature.

--- a/src/MongoDB.Driver.Core/Core/Operations/AsyncCursor.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/AsyncCursor.cs
@@ -555,6 +555,7 @@ namespace MongoDB.Driver.Core.Operations
         public bool MoveNext(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
+            cancellationToken.ThrowIfCancellationRequested();
 
             bool hasMore;
             if (TryMoveNext(out hasMore))
@@ -571,6 +572,7 @@ namespace MongoDB.Driver.Core.Operations
         public async Task<bool> MoveNextAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
+            cancellationToken.ThrowIfCancellationRequested();
 
             bool hasMore;
             if (TryMoveNext(out hasMore))


### PR DESCRIPTION
Evergreen:  https://evergreen.mongodb.com/version/5d9e09732fbabe729ea211ab

It looks like the `.net` driver already has the required behavior. However, I've added a minor change as well as one test.

***UPDATE***:
The full situation is a little bit more interesting than I thought initially. 
See this line: https://github.com/DmitryLukyanov/mongo-csharp-driver/blob/master/src/MongoDB.Driver.Core/Core/Operations/AsyncCursor.cs#L214

We always call `Dispose` when we call `Close` in `AsyncCursor`. It also means that in the next `Dispose` steps, we are closing `channelSource`: https://github.com/DmitryLukyanov/mongo-csharp-driver/blob/master/src/MongoDB.Driver.Core/Core/Operations/AsyncCursor.cs#L417 

And the error which I'm asserting here: https://github.com/DmitryLukyanov/mongo-csharp-driver/pull/63/files#diff-cc1fb01366b2ae2c8316ea97f6b40ff4R99 is most likely to be generated because the cursor tries to access the disposed channel.

Not sure that we can solve this case (without changes in the `closing` logic in `AsyncCursor`, do we want to do it?). Even if we add some additional validation on `closed/disposed` flag before the step when we call `getMore` (as It's done in the java: https://github.com/mongodb/mongo-java-driver/commit/cbf948f5b51b9a71d1f3479840bee42765981d01#diff-72deba1741afe4b2656ca516e99d05c6R110), we always can have a chance that the flag (disposed/closed) has been assigned to `true` after the new validation step.

***UPDATE2***
Probably we can reach the target to avoid calling `getMore` for closed cursor(which is closed from another thread), if we add a `lock` for `Dispose` and `Close` methods in `AsyncCursor`. Together with adding a `ThrowIfDispose` method before this line: https://github.com/mongodb/mongo-csharp-driver/blob/f4cd4affd43976c2650214961db1bd9f61dbb8d0/src/MongoDB.Driver.Core/Core/Operations/AsyncCursor.cs#L565
But, because we allow to call `Close` twice without throwing any errors. Will it be a good idea just to throw an exception(in line `564`) if the cursor is closed in this case? 

***UPDATE3***
The test implementation was rewritten a bit.

cc: @jyemin , @rstam 