### PR TITLE
CSHARP-2801: Fix issues with nested Any.

### DIFF
--- a/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/IntegrationTestBase.cs
@@ -217,6 +217,19 @@ namespace MongoDB.Driver.Tests.Linq
                                 F = 333,
                                 H = 444,
                                 I = new [] { "igloo" }
+                            },
+                            X = new E[]
+                            {
+                                new E()
+                                {
+                                    S = "value 1",
+                                    C = new C()
+                                    {
+                                        D = "value 2",
+                                        Ids = new [] { new ObjectId("222222222222222222222222") }
+                                    },
+                                    I = new [] { "value 3" }
+                                }
                             }
                         },
                         new C
@@ -343,6 +356,7 @@ namespace MongoDB.Driver.Tests.Linq
             public int F { get; set; }
 
             public int H { get; set; }
+            public string S { get; set; }
 
             public IEnumerable<string> I { get; set; }
             public C C { get; set; }

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/PredicateTranslatorTests.cs
@@ -167,7 +167,7 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             Assert(
                 x => x.G.Any(g => g == c1),
                 1,
-                "{ \"G\" : { \"$elemMatch\" : { \"Ids\" : null, \"D\" : \"Dolphin\", \"E\" : { \"F\" : 55, \"H\" : 66, \"I\" : [\"insecure\"], \"C\" : null }, \"S\" : null, \"X\" : null, \"Y\" : null, \"Z\" : null } } }");
+                "{ \"G\" : { \"$elemMatch\" : { \"Ids\" : null, \"D\" : \"Dolphin\", \"E\" : { \"F\" : 55, \"H\" : 66, \"S\": null, \"I\" : [\"insecure\"], \"C\" : null }, \"S\" : null, \"X\" : null, \"Y\" : null, \"Z\" : null } } }");
         }
 
         [Fact]
@@ -310,6 +310,77 @@ namespace MongoDB.Driver.Tests.Linq.Translators
                     ""Y.S"" : { $elemMatch : { ""E"" : null, ""Z"" : { $elemMatch : { ""F"" : 1, ""C.X"" : { $elemMatch : { ""F"" : 4, ""H"" : 0 } } } } } },
                     ""S"" : { $elemMatch : { ""D"" : ""Delilah"", ""Z"" : { $elemMatch : { ""F"" : 1, ""H"" : 0 } } } }
                 } } }");
+        }
+
+        [Fact]
+        public void Any_with_advanced_nested_Anys_and_contains()
+        {
+            Assert(
+                r => r.G != null && r.G.Any(
+                    g => g.X != null && g.X.Any(
+                        x => x.I.Contains("value 3"))),
+                1,
+                "{ G : { '$ne' : null, '$elemMatch' : { 'X' : { '$ne' : null, '$elemMatch' : { 'I' : 'value 3' } } } } }");
+
+            Assert(
+                r => r.G != null && r.G.Any(
+                    g => g.X != null && g.X.Any(
+                        x => x.C.Ids.Contains(new ObjectId("222222222222222222222222")))),
+                1,
+                "{ G : { '$ne' : null, '$elemMatch' : { 'X' : { '$ne' : null, '$elemMatch' : { 'C.Ids' : ObjectId('222222222222222222222222') } } } } }");
+        }
+
+        [Fact]
+        public void Any_with_advanced_nested_Anys_and_endwith()
+        {
+            Assert(
+                r => r.G != null && r.G.Any(
+                    g => g.X != null && g.X.Any(
+                        x => x.S.EndsWith("lue 1"))),
+                1,
+                @"{ G : { '$ne' : null, '$elemMatch' : { 'X' : { '$ne' : null }, 'X.S' : /lue\ 1$/s } } }");
+
+            Assert(
+                r => r.G != null && r.G.Any(
+                    g => g.X != null && g.X.Any(
+                        x => x.C.D.EndsWith("lue 2"))),
+                1,
+                @"{ G : { '$ne' : null, '$elemMatch' : { 'X' : { '$ne' : null }, 'X.C.D' : /lue\ 2$/s } } }");
+        }
+
+        [Fact]
+        public void Any_with_advanced_nested_Anys_and_regex()
+        {
+            var regex = new Regex("^value");
+            Assert(
+                r => r.G != null && r.G.Any(
+                    g => g.X != null && g.X.Any(x => regex.IsMatch(x.S))),
+                1,
+                "{ G : { '$ne' : null, '$elemMatch' : { 'X' : { '$ne' : null, '$elemMatch' : { 'S' : /^value/ } } } } }");
+
+            Assert(
+                r => r.G != null && r.G.Any(
+                    g => g.X != null && g.X.Any(x => regex.IsMatch(x.C.D))),
+                1,
+                "{ G : { '$ne' : null, '$elemMatch' : { 'X' : { '$ne' : null, '$elemMatch' : { 'C.D' : /^value/ } } } } }");
+        }
+
+        [Fact]
+        public void Any_with_advanced_nested_Anys_and_startwith()
+        {
+            Assert(
+                r => r.G != null && r.G.Any(
+                    g => g.X != null && g.X.Any(
+                        x => x.S.StartsWith("value"))),
+                1,
+                "{ G : { '$ne' : null, '$elemMatch' : { 'X' : { '$ne' : null }, 'X.S' : /^value/s } } }");
+
+            Assert(
+                r => r.G != null && r.G.Any(
+                    g => g.X != null && g.X.Any(
+                        x => x.C.D.StartsWith("value"))),
+                1,
+                "{ G : { '$ne' : null, '$elemMatch' : { 'X' : { '$ne' : null }, 'X.C.D' : /^value/s } } }");
         }
 
         [Fact]


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5db6cc5061837d0f894653df

The main idea of this ticket is described in this comment: https://github.com/DmitryLukyanov/mongo-csharp-driver/pull/70#discussion_r339511421

***NOTE***: With the current ticket fix, the change from the ticket 2699 looks unnecessary all tests pass even without this method: https://github.com/mongodb/mongo-csharp-driver/commit/9335995409078ce9a9f2506d56a05bead53e200d#diff-25128dea722dc78fdf02f511b3ea418dR246 
However, I  think there is no harm to have this method too and we can leave it as is.

***NOTE2***: The ticket `CSHARP-2744` can be closed with the comment: `It's implemented in the scope of CSHARP-2801`