### PR TITLE
CSHARP-2569: Require retryable writes network error tests to run on mongos 4.2+.

### DIFF
--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/BulkWriteTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/BulkWriteTest.cs
@@ -65,7 +65,12 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes
 
         protected override void VerifyResult(BsonDocument result)
         {
-            var expectedResult = ParseResult(result);
+            var expectedResult = ParseResult(result, out var expectedInsertedIds);
+            foreach (var insertedId in expectedInsertedIds)
+            {
+                var insertModel = (InsertOneModel<BsonDocument>)_result.ProcessedRequests[insertedId.Key];
+                insertModel.Document["_id"].Should().Be(insertedId.Value);
+            }
             _result.DeletedCount.Should().Be(expectedResult.DeletedCount);
             _result.InsertedCount.Should().Be(expectedResult.InsertedCount);
             _result.MatchedCount.Should().Be(expectedResult.MatchedCount);
@@ -180,12 +185,15 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes
             return result;
         }
 
-        private BulkWriteResult<BsonDocument> ParseResult(BsonDocument result)
+        private BulkWriteResult<BsonDocument> ParseResult(BsonDocument result, out Dictionary<int, int> expectedInsertedIds)
         {
             VerifyFields(result, "deletedCount", "insertedCount", "insertedIds", "matchedCount", "modifiedCount", "upsertedCount", "upsertedIds");
 
             var deletedCount = result["deletedCount"].ToInt64();
-            var insertedCount = result["insertedIds"].AsBsonDocument.ElementCount; // TODO: anything to verify besides count?
+            var insertedCount = result["insertedCount"].ToInt64();
+            expectedInsertedIds = result["insertedIds"]
+                .AsBsonDocument
+                .ToDictionary(k => Convert.ToInt32(k.Name), v => v.Value.ToInt32());
             var matchedCount = result["matchedCount"].ToInt64();
             var modifiedCount = result["modifiedCount"].ToInt64();
             var processedRequests = new List<WriteModel<BsonDocument>>(_requests);

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/DeleteManyTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/DeleteManyTest.cs
@@ -1,0 +1,72 @@
+﻿/* Copyright 2019-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using FluentAssertions;
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.Tests.Specifications.retryable_writes
+{
+    public class DeleteManyTest : RetryableWriteTestBase
+    {
+        // private fields
+        private FilterDefinition<BsonDocument> _filter;
+        private DeleteResult _result;
+
+        // public methods
+        public override void Initialize(BsonDocument operation)
+        {
+            VerifyFields(operation, "name", "arguments");
+
+            foreach (var argument in operation["arguments"].AsBsonDocument)
+            {
+                switch (argument.Name)
+                {
+                    case "filter":
+                        _filter = argument.Value.AsBsonDocument;
+                        break;
+
+                    default:
+                        throw new ArgumentException($"Unexpected argument: {argument.Name}.");
+                }
+            }
+        }
+
+        // protected methods
+        protected override void ExecuteAsync(IMongoCollection<BsonDocument> collection)
+        {
+            _result = collection.DeleteManyAsync(_filter).GetAwaiter().GetResult();
+        }
+
+        protected override void ExecuteSync(IMongoCollection<BsonDocument> collection)
+        {
+            _result = collection.DeleteMany(_filter);
+        }
+
+        protected override void VerifyResult(BsonDocument result)
+        {
+            var expectedResult = ParseResult(result);
+            _result.DeletedCount.Should().Be(expectedResult.DeletedCount);
+        }
+
+        // private methods
+        private DeleteResult ParseResult(BsonDocument result)
+        {
+            VerifyFields(result, "deletedCount");
+            var deletedCount = result["deletedCount"].ToInt64();
+            return new DeleteResult.Acknowledged(deletedCount);
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/UpdateManyTest.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/UpdateManyTest.cs
@@ -1,0 +1,89 @@
+﻿/* Copyright 2019-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using FluentAssertions;
+using MongoDB.Bson;
+
+namespace MongoDB.Driver.Tests.Specifications.retryable_writes
+{
+    public class UpdateManyTest : RetryableWriteTestBase
+    {
+        private FilterDefinition<BsonDocument> _filter;
+        private UpdateDefinition<BsonDocument> _update;
+        private readonly UpdateOptions _options = new UpdateOptions();
+        private UpdateResult _result;
+
+        // public methods
+        public override void Initialize(BsonDocument operation)
+        {
+            VerifyFields(operation, "name", "arguments");
+
+            foreach (var argument in operation["arguments"].AsBsonDocument)
+            {
+                switch (argument.Name)
+                {
+                    case "filter":
+                        _filter = argument.Value.AsBsonDocument;
+                        break;
+
+                    case "update":
+                        _update = argument.Value.AsBsonDocument;
+                        break;
+
+                    case "upsert":
+                        _options.IsUpsert = argument.Value.ToBoolean();
+                        break;
+
+                    default:
+                        throw new ArgumentException($"Unexpected argument: {argument.Name}.");
+                }
+            }
+        }
+
+        // protected methods
+        protected override void ExecuteAsync(IMongoCollection<BsonDocument> collection)
+        {
+            _result = collection.UpdateManyAsync(_filter, _update, _options).GetAwaiter().GetResult();
+        }
+
+        protected override void ExecuteSync(IMongoCollection<BsonDocument> collection)
+        {
+            _result = collection.UpdateMany(_filter, _update, _options);
+        }
+
+        protected override void VerifyResult(BsonDocument result)
+        {
+            var expectedResult = ParseResult(result);
+            _result.MatchedCount.Should().Be(expectedResult.MatchedCount);
+            _result.ModifiedCount.Should().Be(expectedResult.ModifiedCount);
+            _result.UpsertedId.Should().Be(expectedResult.UpsertedId);
+        }
+
+        // private methods
+        private UpdateResult ParseResult(BsonDocument result)
+        {
+            VerifyFields(result, "matchedCount", "modifiedCount", "upsertedCount", "upsertedId");
+
+            var matchedCount = result["matchedCount"].ToInt64();
+            var modifiedCount = result["modifiedCount"].ToInt64();
+            var upsertedCount = result["upsertedCount"].ToInt32();
+            var upsertedId = result.GetValue("upsertedId", null);
+            upsertedCount.Should().Be(upsertedId == null ? 0 : 1);
+
+            return new UpdateResult.Acknowledged(matchedCount, modifiedCount, upsertedId);
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/README.rst
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/README.rst
@@ -19,12 +19,16 @@ Tests will require a MongoClient created with options defined in the tests.
 Integration tests will require a running MongoDB cluster with server versions
 3.6.0 or later. The ``{setFeatureCompatibilityVersion: 3.6}`` admin command
 will also need to have been executed to enable support for retryable writes on
-the cluster.
+the cluster. Some tests may have more stringent version requirements depending
+on the fail points used.
 
 Server Fail Point
 =================
 
-The tests depend on a server fail point, ``onPrimaryTransactionalWrite``, which
+onPrimaryTransactionalWrite
+---------------------------
+
+Some tests depend on a server fail point, ``onPrimaryTransactionalWrite``, which
 allows us to force a network error before the server would return a write result
 to the client. The fail point also allows control whether the server will
 successfully commit the write via its ``failBeforeCommitExceptionCode`` option.
@@ -64,24 +68,36 @@ may be combined if desired:
   If set, the specified exception code will be thrown and the write will not be
   committed. If unset, the write will be allowed to commit.
 
-Disabling Fail Point after Test Execution
------------------------------------------
+failCommand
+-----------
 
-After each test that configures a fail point, drivers should disable the
-``onPrimaryTransactionalWrite`` fail point to avoid spurious failures in
-subsequent tests. The fail point may be disabled like so::
+Some tests depend on a server fail point, ``failCommand``, which allows the
+client to force the server to return an error. Unlike
+``onPrimaryTransactionalWrite``, ``failCommand`` does not allow the client to
+directly control whether the server will commit the operation (execution of the
+write depends on whether the ``closeConnection`` and/or ``errorCode`` options
+are specified). See: `failCommand <../../transactions/tests#failcommand>`_ in
+the Transactions spec test suite for more information.
+
+Disabling Fail Points after Test Execution
+------------------------------------------
+
+After each test that configures a fail point, drivers should disable the fail
+point to avoid spurious failures in subsequent tests. The fail point may be
+disabled like so::
 
     db.runCommand({
-        configureFailPoint: "onPrimaryTransactionalWrite",
+        configureFailPoint: <fail point name>,
         mode: "off"
     });
 
-Network Error Tests
-===================
+Use as Integration Tests
+========================
 
-Network error tests are expressed in YAML and should be run against a replica
-set. These tests cannot be run against a shard cluster because mongos does not
-support the necessary fail point.
+Integration tests are expressed in YAML and can be run against a replica set or
+sharded cluster as denoted by the top-level ``runOn`` field. Tests that rely on
+the ``onPrimaryTransactionalWrite`` fail point cannot be run against a sharded
+cluster because the fail point is not supported by mongos.
 
 The tests exercise the following scenarios:
 
@@ -121,17 +137,29 @@ Test Format
 
 Each YAML file has the following keys:
 
+- ``runOn`` (optional): An array of server version and/or topology requirements
+  for which the tests can be run. If the test environment satisfies one or more
+  of these requirements, the tests may be executed; otherwise, this file should
+  be skipped. If this field is omitted, the tests can be assumed to have no
+  particular requirements and should be executed. Each element will have some or
+  all of the following fields:
+
+  - ``minServerVersion`` (optional): The minimum server version (inclusive)
+    required to successfully run the tests. If this field is omitted, it should
+    be assumed that there is no lower bound on the required server version.
+
+  - ``maxServerVersion`` (optional): The maximum server version (inclusive)
+    against which the tests can be run successfully. If this field is omitted,
+    it should be assumed that there is no upper bound on the required server
+    version.
+
+  - ``topology`` (optional): An array of server topologies against which the
+    tests can be run successfully. Valid topologies are "single", "replicaset",
+    and "sharded". If this field is omitted, the default is all topologies (i.e.
+    ``["single", "replicaset", "sharded"]``).
+
 - ``data``: The data that should exist in the collection under test before each
   test run.
-
-- ``minServerVersion`` (optional): The minimum server version (inclusive)
-  required to successfully run the test. If this field is not present, it should
-  be assumed that there is no lower bound on the required server version.
-
-- ``maxServerVersion`` (optional): The maximum server version (exclusive)
-  against which this test can run successfully. If this field is not present,
-  it should be assumed that there is no upper bound on the required server
-  version.
 
 - ``tests``: An array of tests that are to be run independently of each other.
   Each test will have some or all of the following fields:
@@ -140,9 +168,15 @@ Each YAML file has the following keys:
 
   - ``clientOptions``: Parameters to pass to MongoClient().
 
-  - ``failPoint``: The ``configureFailPoint`` command document to run to
-    configure a fail point on the primary server. Drivers must ensure that
-    ``configureFailPoint`` is the first field in the command.
+  - ``useMultipleMongoses`` (optional): If ``true``, the MongoClient for this
+    test should be initialized with multiple mongos seed addresses. If ``false``
+    or omitted, only a single mongos address should be specified. This field has
+    no effect for non-sharded topologies.
+
+  - ``failPoint`` (optional): The ``configureFailPoint`` command document to run
+    to configure a fail point on the primary server. Drivers must ensure that
+    ``configureFailPoint`` is the first field in the command. This option and
+    ``useMultipleMongoses: true`` are mutually exclusive.
 
   - ``operation``: Document describing the operation to be executed. The
     operation should be executed through a collection object derived from a
@@ -187,9 +221,9 @@ The YAML tests specify bulk write operations that are split by command type
 operations may also be split due to ``maxWriteBatchSize``,
 ``maxBsonObjectSize``, or ``maxMessageSizeBytes``.
 
-For instance, an insertMany operation with five 10 MB documents executed using
+For instance, an insertMany operation with five 10 MiB documents executed using
 OP_MSG payload type 0 (i.e. entire command in one document) would be split into
-five insert commands in order to respect the 16 MB ``maxBsonObjectSize`` limit.
+five insert commands in order to respect the 16 MiB ``maxBsonObjectSize`` limit.
 The same insertMany operation executed using OP_MSG payload type 1 (i.e. command
 arguments pulled out into a separate payload vector) would be split into two
 insert commands in order to respect the 48 MB ``maxMessageSizeBytes`` limit.
@@ -209,59 +243,6 @@ documents in the first command will be processed in the same commit). When
 testing an update or delete that is split into two commands, the ``skip`` should
 be set to the number of statements in the first command to allow the fail point
 to trigger on the second command.
-
-Replica Set Failover Test
-=========================
-
-In addition to network errors, writes should also be retried in the event of a
-primary failover, which results in a "not master" command error (or similar).
-The ``stepdownHangBeforePerformingPostMemberStateUpdateActions`` fail point
-implemented in `d4eb562`_ for `SERVER-31355`_ may be used for this test, as it
-allows a primary to keep its client connections open after a step down. This
-fail point operates by hanging the step down procedure (i.e. ``replSetStepDown``
-command) until the fail point is later deactivated.
-
-.. _d4eb562: https://github.com/mongodb/mongo/commit/d4eb562ac63717904f24de4a22e395070687bc62
-.. _SERVER-31355: https://jira.mongodb.org/browse/SERVER-31355
-
-The following test requires three MongoClient instances and will generally
-require two execution contexts (async drivers may get by with a single thread).
-
-- The client under test will connect to the replica set and be used to execute
-  write operations.
-- The fail point client will connect directly to the initial primary and be used
-  to toggle the fail point.
-- The step down client will connect to the replica set and be used to step down
-  the primary. This client will generally require its own execution context,
-  since the step down will hang.
-
-In order to guarantee that the client under test does not detect the stepped
-down primary's state change via SDAM, it must be configured with a large
-`heartbeatFrequencyMS`_ value (e.g. 60 seconds). Single-threaded drivers may
-also need to set `serverSelectionTryOnce`_ to ``false`` to ensure that server
-selection for the retry attempt waits until a new primary is elected.
-
-.. _heartbeatFrequencyMS: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#heartbeatfrequencyms
-.. _serverSelectionTryOnce: https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#serverselectiontryonce
-
-The test proceeds as follows:
-
-- Using the client under test, insert a document and observe a successful write
-  result. This will ensure that initial discovery takes place.
-- Using the fail point client, activate the fail point by setting ``mode``
-  to ``"alwaysOn"``.
-- Using the step down client, step down the primary by executing the command
-  ``{ replSetStepDown: 60, force: true}``. This operation will hang so long as
-  the fail point is activated. When the fail point is later deactivated, the
-  step down will complete and the primary's client connections will be dropped.
-  At that point, any ensuing network error should be ignored.
-- Using the client under test, insert a document and observe a successful write
-  result. The test MUST assert that the insert command fails once against the
-  stepped down node and is successfully retried on the newly elected primary
-  (after SDAM discovers the topology change). The test MAY use APM or another
-  means to observe both attempts.
-- Using the fail point client, deactivate the fail point by setting ``mode``
-  to ``"off"``.
 
 Command Construction Tests
 ==========================
@@ -293,7 +274,7 @@ unsupported write operations:
 
 * Unsupported write commands
 
-  - ``aggregate`` with ``$out`` pipeline operator
+  - ``aggregate`` with write stage (e.g. ``$out``, ``$merge``)
 
 Drivers should test that transactions IDs are always included in commands for
 supported write operations:
@@ -314,3 +295,33 @@ supported write operations:
   - ``insertMany()`` with ``ordered=false``
   - ``bulkWrite()`` with ``ordered=true`` (no ``UpdateMany`` or ``DeleteMany``)
   - ``bulkWrite()`` with ``ordered=false`` (no ``UpdateMany`` or ``DeleteMany``)
+
+Prose Tests
+===========
+
+The following tests ensure that retryable writes work properly with replica sets
+and sharded clusters.
+
+#. Test that retryable writes raise an exception when using the MMAPv1 storage
+   engine. For this test, execute a write operation, such as ``insertOne``,
+   which should generate an exception. Assert that the error message is the
+   replacement error message::
+
+    This MongoDB deployment does not support retryable writes. Please add
+    retryWrites=false to your connection string.
+
+   and the error code is 20.
+
+Changelog
+=========
+
+:2019-08-07: Add Prose Tests section
+
+:2019-06-07: Mention $merge stage for aggregate alongside $out
+
+:2019-03-01: Add top-level ``runOn`` field to denote server version and/or
+             topology requirements requirements for the test file. Removes the
+             ``minServerVersion`` and ``maxServerVersion`` top-level fields,
+             which are now expressed within ``runOn`` elements.
+
+             Add test-level ``useMultipleMongoses`` field.

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "BulkWrite succeeds after PrimarySteppedDown",
@@ -68,6 +81,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 3
           },
@@ -150,6 +164,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 3
           },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-serverErrors.yml
@@ -1,9 +1,14 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
 
 tests:
     -
@@ -35,6 +40,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 1
                 insertedIds: { 1: 3 }
                 matchedCount: 1
                 modifiedCount: 1
@@ -75,6 +81,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 1
                 insertedIds: { 1: 3 }
                 matchedCount: 1
                 modifiedCount: 1

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite.json
@@ -1,11 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
       "x": 11
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "First command is retried",
@@ -58,6 +65,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -172,6 +180,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 3,
           "insertedIds": {
             "0": 2,
             "2": 3,
@@ -262,6 +271,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -340,6 +350,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -401,6 +412,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 2,
           "insertedIds": {
             "0": 2,
             "1": 3
@@ -483,6 +495,7 @@
         "error": true,
         "result": {
           "deletedCount": 0,
+          "insertedCount": 0,
           "insertedIds": {},
           "matchedCount": 0,
           "modifiedCount": 0,
@@ -554,6 +567,7 @@
         "error": true,
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -636,6 +650,7 @@
         "error": true,
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 2
           },
@@ -699,6 +714,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 2
           },
@@ -763,6 +779,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 2
           },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite.yml
@@ -1,7 +1,10 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset"]
+
 data:
     - { _id: 1, x: 11 }
-
-minServerVersion: '3.6'
 
 tests:
     -
@@ -30,6 +33,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 1
                 insertedIds: { 0: 2 }
                 matchedCount: 1
                 modifiedCount: 1
@@ -86,6 +90,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 3
                 insertedIds: { 0: 2, 2: 3, 4: 5 }
                 matchedCount: 2
                 modifiedCount: 2
@@ -124,6 +129,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 0: 2 }
                 matchedCount: 2
                 modifiedCount: 2
@@ -160,6 +166,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 0: 2 }
                 matchedCount: 2
                 modifiedCount: 2
@@ -190,6 +197,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
+                insertedCount: 2
                 insertedIds: { 0: 2, 1: 3 }
                 matchedCount: 0
                 modifiedCount: 0
@@ -228,6 +236,7 @@ tests:
             error: true
             result:
                 deletedCount: 0
+                insertedCount: 0
                 insertedIds: { }
                 matchedCount: 0
                 modifiedCount: 0
@@ -264,6 +273,7 @@ tests:
             error: true
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 0: 2 }
                 matchedCount: 0
                 modifiedCount: 0
@@ -302,6 +312,7 @@ tests:
             error: true
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 1: 2 }
                 matchedCount: 1
                 modifiedCount: 1
@@ -337,6 +348,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 1
                 insertedIds: { 1: 2 }
                 matchedCount: 0
                 modifiedCount: 0
@@ -372,6 +384,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 1: 2 }
                 matchedCount: 1
                 modifiedCount: 1

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteMany.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteMany.json
@@ -1,0 +1,41 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "DeleteMany ignores retryWrites",
+      "useMultipleMongoses": true,
+      "operation": {
+        "name": "deleteMany",
+        "arguments": {
+          "filter": {}
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 2
+        },
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteMany.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteMany.yml
@@ -1,0 +1,22 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    -
+        description: "DeleteMany ignores retryWrites"
+        useMultipleMongoses: true
+        operation:
+            name: "deleteMany"
+            arguments:
+                filter: { }
+        outcome:
+            result:
+                deletedCount: 2
+            collection:
+                data: []

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "DeleteOne succeeds after PrimarySteppedDown",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.yml
@@ -1,9 +1,14 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "DeleteOne is committed on first attempt",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne.yml
@@ -1,8 +1,11 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-minServerVersion: '3.6'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "FindOneAndDelete succeeds after PrimarySteppedDown",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.yml
@@ -1,9 +1,14 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "FindOneAndDelete is committed on first attempt",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete.yml
@@ -1,8 +1,11 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-minServerVersion: '3.6'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "FindOneAndReplace succeeds after PrimarySteppedDown",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.yml
@@ -1,9 +1,14 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "FindOneAndReplace is committed on first attempt",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace.yml
@@ -1,8 +1,11 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-minServerVersion: '3.6'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "FindOneAndUpdate succeeds after PrimarySteppedDown",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
@@ -1,9 +1,14 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "FindOneAndUpdate is committed on first attempt",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate.yml
@@ -1,8 +1,11 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-minServerVersion: '3.6'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.json
@@ -1,11 +1,24 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
       "x": 11
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "InsertMany succeeds after PrimarySteppedDown",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.yml
@@ -1,8 +1,13 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
+
 data:
     - { _id: 1, x: 11 }
-
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany.json
@@ -1,11 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
       "x": 11
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "InsertMany succeeds after one network error",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany.yml
@@ -1,7 +1,10 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset"]
+
 data:
     - { _id: 1, x: 11 }
-
-minServerVersion: '3.6'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "InsertOne succeeds after connection failure",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.yml
@@ -1,9 +1,14 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "InsertOne is committed on first attempt",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne.yml
@@ -1,8 +1,11 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-minServerVersion: '3.6'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "ReplaceOne succeeds after PrimarySteppedDown",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.yml
@@ -1,9 +1,14 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "ReplaceOne is committed on first attempt",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne.yml
@@ -1,8 +1,11 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-minServerVersion: '3.6'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateMany.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateMany.json
@@ -1,0 +1,57 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateMany ignores retryWrites",
+      "useMultipleMongoses": true,
+      "operation": {
+        "name": "updateMany",
+        "arguments": {
+          "filter": {},
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "matchedCount": 2,
+          "modifiedCount": 2,
+          "upsertedCount": 0
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 23
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateMany.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateMany.yml
@@ -1,0 +1,27 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    -
+        description: "UpdateMany ignores retryWrites"
+        useMultipleMongoses: true
+        operation:
+            name: "updateMany"
+            arguments:
+                filter: { }
+                update: { $inc: { x : 1 }}
+        outcome:
+            result:
+                matchedCount: 2
+                modifiedCount: 2
+                upsertedCount: 0
+            collection:
+                data:
+                  - { _id: 1, x: 12 }
+                  - { _id: 2, x: 23 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "UpdateOne succeeds after PrimarySteppedDown",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.yml
@@ -1,9 +1,14 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
 
 tests:
     -

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "UpdateOne is committed on first attempt",

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne.yml
@@ -1,8 +1,11 @@
+runOn:
+    -
+        minServerVersion: "3.6"
+        topology: ["replicaset"]
+
 data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
-
-minServerVersion: '3.6'
 
 tests:
     -


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5dc1e1b2850e6148eda6bbc9