### PR TITLE
Fix Execute_with_insert_should_not_send_session_id_when_unacknowledged_writes test.

### DIFF
--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
@@ -1286,9 +1286,11 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)] bool async)
         {
             RequireServer.Check();
-            DropCollection();
+
+            var collectionNamespace = CoreTestConfiguration.GetCollectionNamespaceForTestMethod(nameof(BulkMixedWriteOperationTests), nameof(Execute_with_insert_should_not_send_session_id_when_unacknowledged_writes));
+            DropCollection(collectionNamespace);
             var requests = new[] { new InsertRequest(BsonDocument.Parse("{ _id : 1, x : 3 }")) };
-            var subject = new BulkMixedWriteOperation(_collectionNamespace, requests, _messageEncoderSettings)
+            var subject = new BulkMixedWriteOperation(collectionNamespace, requests, _messageEncoderSettings)
             {
                 WriteConcern = WriteConcern.Unacknowledged
             };

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/BulkMixedWriteOperationTests.cs
@@ -1256,9 +1256,11 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)] bool async)
         {
             RequireServer.Check();
-            DropCollection();
+
+            var collectionNamespace = CoreTestConfiguration.GetCollectionNamespaceForTestMethod(nameof(BulkMixedWriteOperationTests), nameof(Execute_with_delete_should_not_send_session_id_when_unacknowledged_writes));
+            DropCollection(collectionNamespace);
             var requests = new[] { new DeleteRequest(BsonDocument.Parse("{ x : 1 }")) };
-            var subject = new BulkMixedWriteOperation(_collectionNamespace, requests, _messageEncoderSettings)
+            var subject = new BulkMixedWriteOperation(collectionNamespace, requests, _messageEncoderSettings)
             {
                 WriteConcern = WriteConcern.Unacknowledged
             };
@@ -1318,9 +1320,11 @@ namespace MongoDB.Driver.Core.Operations
             [Values(false, true)] bool async)
         {
             RequireServer.Check();
-            DropCollection();
+
+            var collectionNamespace = CoreTestConfiguration.GetCollectionNamespaceForTestMethod(nameof(BulkMixedWriteOperationTests), nameof(Execute_with_update_should_not_send_session_id_when_unacknowledged_writes));
+            DropCollection(collectionNamespace);
             var requests = new[] { new UpdateRequest(UpdateType.Update, BsonDocument.Parse("{ x : 1 }"), BsonDocument.Parse("{ $set : { a : 1 } }")) };
-            var subject = new BulkMixedWriteOperation(_collectionNamespace, requests, _messageEncoderSettings)
+            var subject = new BulkMixedWriteOperation(collectionNamespace, requests, _messageEncoderSettings)
             {
                 WriteConcern = WriteConcern.Unacknowledged
             };


### PR DESCRIPTION
This PR to fix the failed tests in master: https://evergreen.mongodb.com/task_log_raw/dot_net_driver_tests_snappy_compression__version~4.2_os~windows_64_topology~standalone_auth~noauth_ssl~nossl_compressor~snappy_test_patch_d3c29e0f3338ebed52b0ef3f5d95c2c1d9092ce1_5dc008859ccd4e1299fe0260_19_11_04_11_16_22/0?type=T#L1208. 
I didn't notice this problem in the scope of 2199.

Evergreen: https://evergreen.mongodb.com/version/5dc349a4850e61657e0ea2dc