### PR TITLE
CSHARP-2855: Fix typo error.

### DIFF
--- a/tests/MongoDB.Driver.Examples/TransactionExamplesForDocs/WithTransactionExample1.cs
+++ b/tests/MongoDB.Driver.Examples/TransactionExamplesForDocs/WithTransactionExample1.cs
@@ -41,7 +41,7 @@ namespace MongoDB.Driver.Examples.TransactionExamplesForDocs
             // For a replica set, include the replica set name and a seedlist of the members in the URI string; e.g.
             // string uri = "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?replicaSet=myRepl";
             // For a sharded cluster, connect to the mongos instances; e.g.
-            // string uri = "mongodb://mongos0.example.com:27017,mongos1.example.com:27017:27017/";
+            // string uri = "mongodb://mongos0.example.com:27017,mongos1.example.com:27017/";
             var client = new MongoClient(connectionString);
 
             // Prereq: Create collections. CRUD operations in transactions must be on existing collections.


### PR DESCRIPTION
See: https://github.com/mongodb/mongo-csharp-driver/commit/9a1d7763b1a2354eeddae0394ea34216cc17bfd6#r35966142