### PR TITLE
CSHARP-2216: Update algorithm for Kerberos hostname canonicalization

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -158,7 +158,7 @@ Task("TestGssapi")
             NoRestore = true,
             Configuration = configuration,
             ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
-			Filter = "Category=\"GssapiMechanism\""
+            Filter = "Category=\"GssapiMechanism\""
         }
     );
 });

--- a/build.cake
+++ b/build.cake
@@ -145,6 +145,24 @@ Task("TestAtlasConnectivity")
     );
 });
 
+Task("TestGssapi")
+    .IsDependentOn("Build")
+    .DoesForEach(
+        GetFiles("./**/MongoDB.Driver.Tests.csproj"),
+        testProject => 
+{
+    DotNetCoreTest(
+        testProject.FullPath,
+        new DotNetCoreTestSettings {
+            NoBuild = true,
+            NoRestore = true,
+            Configuration = configuration,
+            ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
+			Filter = "Category=\"GssapiMechanism\""
+        }
+    );
+});
+
 Task("Docs")
     .IsDependentOn("ApiDocs")
     .IsDependentOn("RefDocs");

--- a/build.cake
+++ b/build.cake
@@ -133,35 +133,35 @@ Task("TestAtlasConnectivity")
     .DoesForEach(
         GetFiles("./**/AtlasConnectivity.Tests.csproj"),
         testProject => 
-{
-    DotNetCoreTest(
-        testProject.FullPath,
-        new DotNetCoreTestSettings {
-            NoBuild = true,
-            NoRestore = true,
-            Configuration = configuration,
-            ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64")
-        }
-    );
-});
+	{
+		DotNetCoreTest(
+			testProject.FullPath,
+			new DotNetCoreTestSettings {
+				NoBuild = true,
+				NoRestore = true,
+				Configuration = configuration,
+				ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64")
+			}
+		);
+	});
 
 Task("TestGssapi")
     .IsDependentOn("Build")
     .DoesForEach(
         GetFiles("./**/MongoDB.Driver.Tests.csproj"),
         testProject => 
-{
-    DotNetCoreTest(
-        testProject.FullPath,
-        new DotNetCoreTestSettings {
-            NoBuild = true,
-            NoRestore = true,
-            Configuration = configuration,
-            ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
-            Filter = "Category=\"GssapiMechanism\""
-        }
-    );
-});
+	{
+		DotNetCoreTest(
+			testProject.FullPath,
+			new DotNetCoreTestSettings {
+				NoBuild = true,
+				NoRestore = true,
+				Configuration = configuration,
+				ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64"),
+				Filter = "Category=\"GssapiMechanism\""
+			}
+		);
+	});
 
 Task("Docs")
     .IsDependentOn("ApiDocs")

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -236,7 +236,7 @@ functions:
       params:
         working_dir: mongo-csharp-driver
         script: |
-          MONGODB_URI="${MONGODB_URI}" AUTH_HOST="${AUTH_HOST}" AUTH_GSSAPI="${AUTH_GSSAPI}" evergreen/run-gssapi-auth-tests.sh
+          AUTH_HOST="${AUTH_HOST}" AUTH_GSSAPI="${AUTH_GSSAPI}" evergreen/run-gssapi-auth-tests.sh
     
   run-plain-auth-tests:
     - command: shell.exec

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -236,8 +236,7 @@ functions:
       params:
         working_dir: mongo-csharp-driver
         script: |
-          ${PREPARE_SHELL}
-          MONGODB_URI="${gssapi_auth_mongodb_uri}" evergreen/run-gssapi-auth-tests.sh
+          MONGODB_URI="${MONGODB_URI}" AUTH_HOST="${AUTH_HOST}" AUTH_GSSAPI="${AUTH_GSSAPI}" evergreen/run-gssapi-auth-tests.sh
     
   run-plain-auth-tests:
     - command: shell.exec

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -230,6 +230,15 @@ functions:
           # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
           ATLAS_FREE="${ATLAS_FREE}" ATLAS_FREE_SRV="${ATLAS_FREE_SRV}" ATLAS_REPLICA="${ATLAS_REPLICA}" ATLAS_REPLICA_SRV="${ATLAS_REPLICA_SRV}" ATLAS_SHARDED="${ATLAS_SHARDED}" ATLAS_SHARDED_SRV="${ATLAS_SHARDED_SRV}" ATLAS_TLS11="${ATLAS_TLS11}" ATLAS_TLS11_SRV="${ATLAS_TLS11_SRV}" ATLAS_TLS12="${ATLAS_TLS12}" ATLAS_TLS12_SRV="${ATLAS_TLS12_SRV}" evergreen/run-atlas-connectivity-tests.sh
 
+  run-gssapi-auth-tests:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: mongo-csharp-driver
+        script: |
+          ${PREPARE_SHELL}
+          MONGODB_URI="${gssapi_auth_mongodb_uri}" evergreen/run-gssapi-auth-tests.sh
+    
   run-plain-auth-tests:
     - command: shell.exec
       type: test
@@ -340,6 +349,13 @@ tasks:
           name: compile
       commands:
         - func: run-atlas-connectivity-tests
+
+    - name: gssapi-auth-tests
+      depends_on:
+        - variant: windows-64-compile
+          name: compile
+      commands:
+        - func: run-gssapi-auth-tests
 
     - name: plain-auth-tests
       depends_on:
@@ -496,6 +512,13 @@ buildvariants:
     - windows-64-vs2017-test
   tasks:
     - name: atlas-connectivity-tests
+
+- name: gssapi-auth-tests
+  display_name: "GSSAPI (Kerberos) Auth tests"
+  run_on:
+    - windows-64-vs2017-test
+  tasks:
+    - name: gssapi-auth-tests
 
 # - name: plain-auth-tests
 #   display_name: "PLAIN (LDAP) Auth tests"

--- a/evergreen/run-gssapi-auth-tests.sh
+++ b/evergreen/run-gssapi-auth-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Don't trace since the URI contains a password that shouldn't show up in the logs
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Supported/used environment variables:
+#       MONGODB_URI             Set the URI, including username/password to use to connect to the server via GSSAPI authentication mechanism
+
+############################################
+#            Main Program                  #
+############################################
+echo "Running GSSAPI authentication tests"
+
+# Provision the correct connection string and set up SSL if needed
+for var in TMP TEMP NUGET_PACKAGES NUGET_HTTP_CACHE_PATH APPDATA; do setx $var z:\\data\\tmp; export $var=z:\\data\\tmp; done
+
+if [ "Windows_NT" = "$OS" ]; then
+  cmd /c "REG ADD HKLM\SYSTEM\ControlSet001\Control\Lsa\Kerberos\Domains\LDAPTEST.10GEN.CC /v KdcNames /d ldaptest.10gen.cc /t REG_MULTI_SZ /f"
+  echo "LDAPTEST.10GEN.CC registry has been added"
+  
+  cmd /c "REG ADD HKLM\SYSTEM\ControlSet001\Control\Lsa\Kerberos\Domains\LDAPTEST2.10GEN.CC /v KdcNames /d ldaptest.10gen.cc /t REG_MULTI_SZ /f"
+  echo "LDAPTEST2.10GEN.CC registry has been added"
+fi;
+
+export EXPLICIT=true
+
+# Arguments for AUTH_GSSAPI + AUTH_HOST
+export MONGODB_URI="mongodb://${AUTH_GSSAPI}@${AUTH_HOST}:27017/kerberos?authMechanism=GSSAPI"
+
+powershell.exe .\\build.ps1 -target TestGssapi

--- a/evergreen/run-gssapi-auth-tests.sh
+++ b/evergreen/run-gssapi-auth-tests.sh
@@ -4,7 +4,8 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:
-#       MONGODB_URI             Set the URI, including username/password to use to connect to the server via GSSAPI authentication mechanism
+#       AUTH_HOST             Set the hostname of a key distribution center (KDC)
+#       AUTH_GSSAPI           Set the GSSAPI credentials, including a user principal/password to use to connect to AUTH_HOST server via GSSAPI authentication mechanism
 
 ############################################
 #            Main Program                  #

--- a/evergreen/run-gssapi-auth-tests.sh
+++ b/evergreen/run-gssapi-auth-tests.sh
@@ -25,7 +25,4 @@ fi;
 
 export EXPLICIT=true
 
-# Arguments for AUTH_GSSAPI + AUTH_HOST
-export MONGODB_URI="mongodb://${AUTH_GSSAPI}@${AUTH_HOST}:27017/kerberos?authMechanism=GSSAPI"
-
 powershell.exe .\\build.ps1 -target TestGssapi

--- a/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
@@ -220,7 +220,7 @@ namespace MongoDB.Driver.Core.Authentication
 
                 if (_canonicalizeHostName)
                 {
-                    hostName = _dnsResolver.GetCanonicalHostName(hostName);
+                    hostName = _dnsResolver.GetHostNameWithReverseDnsLookup(hostName);
                 }
 
                 return new FirstStep(_serviceName, hostName, _realm, _username, _password, conversation);

--- a/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
@@ -220,7 +220,11 @@ namespace MongoDB.Driver.Core.Authentication
 
                 if (_canonicalizeHostName)
                 {
-                    hostName = _dnsResolver.GetHostNameWithReverseDnsLookup(hostName);
+                    var canonicalizedHostName = _dnsResolver.GetHostNameWithReverseDnsLookup(hostName);
+                    if (canonicalizedHostName != null)
+                    {
+                        hostName = canonicalizedHostName;
+                    }
                 }
 
                 return new FirstStep(_serviceName, hostName, _realm, _username, _password, conversation);

--- a/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/GssapiAuthenticator.cs
@@ -190,7 +190,7 @@ namespace MongoDB.Driver.Core.Authentication
                 _realm = realm;
                 _username = Ensure.IsNotNullOrEmpty(username, nameof(username));
                 _password = password;
-                _dnsResolver = new DnsClientWrapper();
+                _dnsResolver = DnsClientWrapper.Instance;
             }
 
             public string Name
@@ -220,7 +220,7 @@ namespace MongoDB.Driver.Core.Authentication
 
                 if (_canonicalizeHostName)
                 {
-                    var canonicalizedHostName = _dnsResolver.GetHostNameWithReverseDnsLookup(hostName);
+                    var canonicalizedHostName = _dnsResolver.GetCanonicalizedHostName(hostName);
                     if (canonicalizedHostName != null)
                     {
                         hostName = canonicalizedHostName;

--- a/src/MongoDB.Driver.Core/Core/Misc/DnsClientWrapper.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/DnsClientWrapper.cs
@@ -38,7 +38,7 @@ namespace MongoDB.Driver.Core.Misc
         public LookupClient LookupClient => _lookupClient;
 
         // public methods
-        public string GetCanonicalHostName(string hostNameOrAddress)
+        public string GetHostNameWithReverseDnsLookup(string hostNameOrAddress)
         {
             var hostEntry = _lookupClient.GetHostEntry(hostNameOrAddress);
             if (hostEntry.Aliases != null && hostEntry.Aliases.Length > 0)

--- a/src/MongoDB.Driver.Core/Core/Misc/DnsClientWrapper.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/DnsClientWrapper.cs
@@ -41,14 +41,18 @@ namespace MongoDB.Driver.Core.Misc
         public string GetHostNameWithReverseDnsLookup(string hostNameOrAddress)
         {
             var hostEntry = _lookupClient.GetHostEntry(hostNameOrAddress);
-            if (hostEntry.Aliases != null && hostEntry.Aliases.Length > 0)
+            if (hostEntry != null)
             {
-                return hostEntry.Aliases[0];
+                if (hostEntry.Aliases != null && hostEntry.Aliases.Length > 0)
+                {
+                    return hostEntry.Aliases[0];
+                }
+                else
+                {
+                    return hostEntry.HostName;
+                }
             }
-            else
-            {
-                return hostNameOrAddress;
-            }
+            return null;
         }
 
         public List<SrvRecord> ResolveSrvRecords(string service, CancellationToken cancellationToken)

--- a/src/MongoDB.Driver.Core/Core/Misc/DnsClientWrapper.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/DnsClientWrapper.cs
@@ -38,6 +38,19 @@ namespace MongoDB.Driver.Core.Misc
         public LookupClient LookupClient => _lookupClient;
 
         // public methods
+        public string GetCanonicalHostName(string hostNameOrAddress)
+        {
+            var hostEntry = _lookupClient.GetHostEntry(hostNameOrAddress);
+            if (hostEntry.Aliases != null && hostEntry.Aliases.Length > 0)
+            {
+                return hostEntry.Aliases[0];
+            }
+            else
+            {
+                return hostNameOrAddress;
+            }
+        }
+
         public List<SrvRecord> ResolveSrvRecords(string service, CancellationToken cancellationToken)
         {
             Ensure.IsNotNull(service, nameof(service));

--- a/src/MongoDB.Driver.Core/Core/Misc/IDnsResolver.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/IDnsResolver.cs
@@ -45,7 +45,7 @@ namespace MongoDB.Driver.Core.Misc
 
     internal interface IDnsResolver
     {
-        string GetCanonicalHostName(string hostNameOrAddress);
+        string GetHostNameWithReverseDnsLookup(string hostNameOrAddress);
         List<SrvRecord> ResolveSrvRecords(string service, CancellationToken cancellation);
         Task<List<SrvRecord>> ResolveSrvRecordsAsync(string service, CancellationToken cancellation);
         List<TxtRecord> ResolveTxtRecords(string domainName, CancellationToken cancellation);

--- a/src/MongoDB.Driver.Core/Core/Misc/IDnsResolver.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/IDnsResolver.cs
@@ -45,7 +45,7 @@ namespace MongoDB.Driver.Core.Misc
 
     internal interface IDnsResolver
     {
-        string GetHostNameWithReverseDnsLookup(string hostNameOrAddress);
+        string GetCanonicalizedHostName(string hostNameOrAddress);
         List<SrvRecord> ResolveSrvRecords(string service, CancellationToken cancellation);
         Task<List<SrvRecord>> ResolveSrvRecordsAsync(string service, CancellationToken cancellation);
         List<TxtRecord> ResolveTxtRecords(string domainName, CancellationToken cancellation);

--- a/src/MongoDB.Driver.Core/Core/Misc/IDnsResolver.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/IDnsResolver.cs
@@ -45,6 +45,7 @@ namespace MongoDB.Driver.Core.Misc
 
     internal interface IDnsResolver
     {
+        string GetCanonicalHostName(string hostNameOrAddress);
         List<SrvRecord> ResolveSrvRecords(string service, CancellationToken cancellation);
         Task<List<SrvRecord>> ResolveSrvRecordsAsync(string service, CancellationToken cancellation);
         List<TxtRecord> ResolveTxtRecords(string domainName, CancellationToken cancellation);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
@@ -36,7 +36,7 @@ namespace MongoDB.Driver.Core.Clusters
         [Theory]
         [InlineData("test", "test")]
         [InlineData("test.test", "test.test")]
-        [InlineData("127.0.0", null)]
+        [InlineData("128.0.0", null)]
         public void GetHostNameWithReverseDnsLookup_should_return_input_value_for_incorrect_host_name(string host, string expectedHost)
         {
             var subject = new DnsClientWrapper();

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
@@ -34,23 +34,24 @@ namespace MongoDB.Driver.Core.Clusters
         }
 
         [Theory]
-        [InlineData("test", "test")]
-        [InlineData("test.test", "test.test")]
-        [InlineData("128.0.0", null)]
-        public void GetHostNameWithReverseDnsLookup_should_return_input_value_for_incorrect_host_name(string host, string expectedHost)
+        [InlineData("54.225.237.121", "ldaptest.10gen.cc")]
+        [InlineData("ec2-54-225-237-121.compute-1.amazonaws.com", "ldaptest.10gen.cc")]
+        [InlineData("ldaptest.10gen.cc", "ldaptest.10gen.cc")]
+        [InlineData("azure.microsoft.com", "l-0007.l-msedge.net")]
+        public void GetCanonicalizedHostName_should_return_expected_result(string host, string expectedHost)
         {
             var subject = new DnsClientWrapper();
 
-            var result = subject.GetHostNameWithReverseDnsLookup(host);
+            var result = subject.GetCanonicalizedHostName(host);
             result.Should().Be(expectedHost);
         }
 
         [Fact]
-        public void GetHostNameWithReverseDnsLookup_should_throw_when_host_is_null()
+        public void GetCanonicalizedHostName_should_throw_when_host_is_null()
         {
             var subject = new DnsClientWrapper();
 
-            var exception = Record.Exception(() => subject.GetHostNameWithReverseDnsLookup(null));
+            var exception = Record.Exception(() => subject.GetCanonicalizedHostName(null));
             exception.Should().BeOfType<ArgumentNullException>();
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
@@ -44,6 +44,17 @@ namespace MongoDB.Driver.Core.Clusters
         }
 
         [Theory]
+        [InlineData("ldaptest.10gen.cc", "ldaptest.10gen.cc")]
+        [InlineData("ec2-54-225-237-121.compute-1.amazonaws.com", "ec2-54-225-237-121.compute-1.amazonaws.com")]
+        [InlineData("54.225.237.121", "ldaptest.10gen.cc")]
+        public void GetHostNameWithReverseDnsLookup_should_return_expected_result(string hostName, string expectedHostName)
+        {
+            var subject = new DnsClientWrapper();
+            var result = subject.GetHostNameWithReverseDnsLookup(hostName);
+            result.Should().Be(expectedHostName);
+        }
+
+        [Theory]
         [InlineData("_mongodb._tcp.test5.test.build.10gen.cc", new[] { "localhost.test.build.10gen.cc.:27017" }, false)]
         [InlineData("_mongodb._tcp.test5.test.build.10gen.cc", new[] { "localhost.test.build.10gen.cc.:27017" }, true)]
         public void ResolveSrvRecords_should_return_expected_result(string service, string[] expectedEndPoints, bool async)

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
@@ -33,6 +33,27 @@ namespace MongoDB.Driver.Core.Clusters
             subject.LookupClient.Should().NotBeNull();
         }
 
+        [Theory]
+        [InlineData("test", "test")]
+        [InlineData("test.test", "test.test")]
+        [InlineData("127.0.0", null)]
+        public void GetHostNameWithReverseDnsLookup_should_return_input_value_for_incorrect_host_name(string host, string expectedHost)
+        {
+            var subject = new DnsClientWrapper();
+
+            var result = subject.GetHostNameWithReverseDnsLookup(host);
+            result.Should().Be(expectedHost);
+        }
+
+        [Fact]
+        public void GetHostNameWithReverseDnsLookup_should_throw_when_host_is_null()
+        {
+            var subject = new DnsClientWrapper();
+
+            var exception = Record.Exception(() => subject.GetHostNameWithReverseDnsLookup(null));
+            exception.Should().BeOfType<ArgumentNullException>();
+        }
+
         [Fact]
         public void LookupClient_should_return_expected_result()
         {
@@ -41,17 +62,6 @@ namespace MongoDB.Driver.Core.Clusters
             var result = subject.LookupClient;
 
             result.Should().NotBeNull();
-        }
-
-        [Theory]
-        [InlineData("ldaptest.10gen.cc", "ldaptest.10gen.cc")]
-        [InlineData("ec2-54-225-237-121.compute-1.amazonaws.com", "ec2-54-225-237-121.compute-1.amazonaws.com")]
-        [InlineData("54.225.237.121", "ldaptest.10gen.cc")]
-        public void GetHostNameWithReverseDnsLookup_should_return_expected_result(string hostName, string expectedHostName)
-        {
-            var subject = new DnsClientWrapper();
-            var result = subject.GetHostNameWithReverseDnsLookup(hostName);
-            result.Should().Be(expectedHostName);
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Tests/Communication/Security/GssapiAuthenticationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Communication/Security/GssapiAuthenticationTests.cs
@@ -15,10 +15,9 @@
 
 using System;
 using System.Linq;
+using System.Net;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
-using MongoDB.Driver.Core.Authentication;
-using MongoDB.Driver.Core.Configuration;
 using Xunit;
 
 namespace MongoDB.Driver.Tests.Communication.Security
@@ -34,6 +33,19 @@ namespace MongoDB.Driver.Tests.Communication.Security
         public GssapiAuthenticationTests()
         {
             _settings = MongoClientSettings.FromUrl(new MongoUrl(CoreTestConfiguration.ConnectionString.ToString()));
+        }
+
+        [SkippableFact]
+        public void Canonicalize_host_name_with_GSSAPI_should_work_as_expected()
+        {
+            RequireEnvironment.Check().EnvironmentVariable("EXPLICIT");
+
+            var hostEntry = Dns.GetHostEntry("LDAPTEST.10GEN.CC");
+            var ipAddress = hostEntry.AddressList.First();;
+            var connectionString = $"mongodb://drivers%40LDAPTEST.10GEN.CC:powerbook17@{ipAddress}/kerberos?authMechanism=GSSAPI&authMechanismProperties=CANONICALIZE_HOST_NAME:true";
+            var client = new MongoClient(connectionString);
+            var db = client.GetDatabase("db");
+            db.RunCommand<BsonDocument>(new BsonDocument("ping", 1));
         }
 
         [SkippableFact]

--- a/tests/MongoDB.Driver.Tests/Communication/Security/GssapiAuthenticationTests.cs
+++ b/tests/MongoDB.Driver.Tests/Communication/Security/GssapiAuthenticationTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
 using Xunit;
@@ -28,20 +29,25 @@ namespace MongoDB.Driver.Tests.Communication.Security
     {
         private static readonly string __collectionName = "test";
 
+        public string AuthHost => Environment.GetEnvironmentVariable("AUTH_HOST") ?? throw new Exception("AUTH_HOST has not been configured.");
+
         [SkippableFact]
         public void Authentication_with_canonicalize_host_name_and_ip_host_should_work_as_expected()
         {
             RequireEnvironment.Check().EnvironmentVariable("EXPLICIT");
 
-            var authHost = Environment.GetEnvironmentVariable("AUTH_HOST") ?? throw new Exception("AUTH_HOST has not been configured.");
-            var authGssapi = Environment.GetEnvironmentVariable("AUTH_GSSAPI") ?? throw new Exception("AUTH_GSSAPI has not been configured.");
-            var hostEntry = Dns.GetHostEntry(authHost);
-            var ipAddress = hostEntry.AddressList.First();
-            var connectionString = $"mongodb://{authGssapi}@{ipAddress}/kerberos?authMechanism=GSSAPI&authMechanismProperties=CANONICALIZE_HOST_NAME:true";
+            var hostEntry = Dns.GetHostEntry(AuthHost);
+            var ipAddress = hostEntry.AddressList.First().ToString();
+            var connectionString = CreateGssapiConnectionString(ipAddress, "&authMechanismProperties=CANONICALIZE_HOST_NAME:true");
+            var mongoUrl = new MongoUrl(connectionString);
 
-            var client = new MongoClient(connectionString);
-            var db = client.GetDatabase("db");
-            db.RunCommand<BsonDocument>(new BsonDocument("ping", 1));
+            var client = new MongoClient(mongoUrl);
+            var collection = GetTestCollection(client, mongoUrl.DatabaseName);
+            var result = collection
+                .FindSync(new BsonDocument())
+                .ToList();
+
+            result.Should().NotBeNull();
         }
 
         [SkippableFact]
@@ -49,19 +55,17 @@ namespace MongoDB.Driver.Tests.Communication.Security
         {
             RequireEnvironment.Check().EnvironmentVariable("EXPLICIT");
 
-            var clientSettings = CreateClientSettings();
+            var mongoUrl = CreateMongoUrl();
+            var clientSettings = MongoClientSettings.FromUrl(mongoUrl);
             clientSettings.Credential = null;
             var client = new MongoClient(clientSettings);
+            var collection = GetTestCollection(client, mongoUrl.DatabaseName);
 
-            Assert.Throws<MongoCommandException>(() =>
-            {
 #pragma warning disable 618
-                client
-                    .GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName)
-                    .GetCollection<BsonDocument>(__collectionName)
-                    .Count(new BsonDocument());
+            var exception = Record.Exception(() => { collection.Count(new BsonDocument()); });
 #pragma warning restore
-            });
+            var e = exception.Should().BeOfType<MongoCommandException>().Subject;
+            e.CodeName.Should().Be("Unauthorized");
         }
 
 
@@ -70,16 +74,15 @@ namespace MongoDB.Driver.Tests.Communication.Security
         {
             RequireEnvironment.Check().EnvironmentVariable("EXPLICIT");
 
-            var clientSettings = CreateClientSettings();
-            var client = new MongoClient(clientSettings);
+            var mongoUrl = CreateMongoUrl();
+            var client = new MongoClient(mongoUrl);
 
-            var result = client
-                .GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName)
-                .GetCollection<BsonDocument>(__collectionName)
+            var collection = GetTestCollection(client, mongoUrl.DatabaseName);
+            var result = collection
                 .FindSync(new BsonDocument())
                 .ToList();
 
-            Assert.NotNull(result);
+            result.Should().NotBeNull();
         }
 
         [SkippableFact]
@@ -87,26 +90,38 @@ namespace MongoDB.Driver.Tests.Communication.Security
         {
             RequireEnvironment.Check().EnvironmentVariable("EXPLICIT");
 
-            var clientSettings = CreateClientSettings();
-            var currentCredentialUsername = clientSettings.Credential.Username;
+            var mongoUrl = CreateMongoUrl();
+            var currentCredentialUsername = mongoUrl.Username;
+            var clientSettings = MongoClientSettings.FromUrl(mongoUrl);
             clientSettings.Credential = MongoCredential.CreateGssapiCredential(currentCredentialUsername, "wrongPassword");
 
             var client = new MongoClient(clientSettings);
+            var collection = GetTestCollection(client, mongoUrl.DatabaseName);
 
-            Assert.Throws<MongoAuthenticationException>(() =>
-            {
-                client
-                    .GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName)
-                    .GetCollection<BsonDocument>(__collectionName)
-                    .FindSync(new BsonDocument())
-                    .ToList();
-            });
+            var exception = Record.Exception(() => { collection.FindSync(new BsonDocument()).ToList(); });
+            var e = exception.Should().BeOfType<MongoAuthenticationException>().Subject;
+            e.InnerException.Message.Should().Be("The logon failed.");
         }
 
         // private methods
-        private MongoClientSettings CreateClientSettings()
+        private string CreateGssapiConnectionString(string authHost, string mechanismProperty = null)
         {
-            return MongoClientSettings.FromUrl(new MongoUrl(CoreTestConfiguration.ConnectionString.ToString()));
+            var authGssapi = Environment.GetEnvironmentVariable("AUTH_GSSAPI") ?? throw new Exception("AUTH_GSSAPI has not been configured.");
+
+            return $"mongodb://{authGssapi}@{authHost}/kerberos?authMechanism=GSSAPI{mechanismProperty}";
+        }
+
+        private MongoUrl CreateMongoUrl()
+        {
+            var connectionString = CreateGssapiConnectionString(AuthHost);
+            return MongoUrl.Create(connectionString);
+        }
+
+        private IMongoCollection<BsonDocument> GetTestCollection(MongoClient client, string databaseName)
+        {
+            return client
+                .GetDatabase(databaseName)
+                .GetCollection<BsonDocument>(__collectionName);
         }
     }
 }


### PR DESCRIPTION
Evergreen(UPDATED): https://evergreen.mongodb.com/version/5df813bc0ae60660c817b44c

NOTE: Below I've provided the results of this logic in different implementations (Python/Java/c#): https://docs.google.com/document/d/145oeuIYo-2OMmZC8P68LaPI_RfSuaQw3buC_yKB9qb0/edit?usp=sharing

NOTE2: Here Python code which I took as example:
    
    from socket import *

    def canonicalize(ipaddr):
        af, socktype, proto, canonname, sockaddr = getaddrinfo(
            ipaddr, 80, 0, 0, IPPROTO_TCP, AI_CANONNAME)[0]
        print('canonical name from getaddrinfo: [%s]' % (canonname,))


    try:

        # NI_NAMEREQD requests an error if getnameinfo fails.
        name = getnameinfo(sockaddr, NI_NAMEREQD)

    except gaierror as exc:
        print('getname info failed: "%s"' % (exc,))
        return canonname.lower()

    return name[0].lower()

    #name = canonicalize('54.225.237.121') #ldaptest.10gen.cc
    #name = canonicalize('ec2-54-225-237-121.compute-1.amazonaws.com') #ldaptest.10gen.cc
    #name = canonicalize('azure.microsoft.com') #l-0007.l-msedge.net
    #name = canonicalize('ldaptest.10gen.cc') #ldaptest.10gen.cc

    print('canonicalized: [%s]' % (name,)) 

The above code can be executed from here: https://www.onlinegdb.com/online_python_compiler

**NOTE3**: sounds like we need to create a spec ticket to clarify which way to resolve DNS host is correct. Also It will be good to avoid references on low level native method like `getaddrinfo` and `getnameinfo` and try to use `**ANSWER SECTION**` in the query response (similar to how it's done in srv). See `dig.com` results on the second page of the above google doc. At least we can discuss it.