### PR TITLE
CSHARP-2289: Only send bypassDocumentValidation if it's true.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Operations/AggregateToCollectionOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/AggregateToCollectionOperation.cs
@@ -262,7 +262,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "aggregate", _collectionNamespace == null ? (BsonValue)1 : _collectionNamespace.CollectionName },
                 { "pipeline", new BsonArray(_pipeline) },
                 { "allowDiskUse", () => _allowDiskUse.Value, _allowDiskUse.HasValue },
-                { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
+                { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.GetValueOrDefault() && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
                 { "collation", () => _collation.ToBsonDocument(), _collation != null },
                 { "readConcern", readConcern, readConcern != null },

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndReplaceOperation.cs
@@ -176,7 +176,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "upsert", true, _isUpsert },
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
                 { "writeConcern", writeConcern, writeConcern != null },
-                { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
+                { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.GetValueOrDefault() && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
                 { "collation", () => Collation.ToBsonDocument(), Collation != null },
                 { "txnNumber", () => transactionNumber, transactionNumber.HasValue }
             };

--- a/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/FindOneAndUpdateOperation.cs
@@ -186,7 +186,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "upsert", true, _isUpsert },
                 { "maxTimeMS", () => MaxTimeHelper.ToMaxTimeMS(_maxTime.Value), _maxTime.HasValue },
                 { "writeConcern", writeConcern, writeConcern != null },
-                { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
+                { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.GetValueOrDefault() && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
                 { "collation", () => Collation.ToBsonDocument(), Collation != null },
                 { "arrayFilters", () => new BsonArray(_arrayFilters), _arrayFilters != null },
                 { "txnNumber", () => transactionNumber, transactionNumber.HasValue }

--- a/src/MongoDB.Driver.Core/Core/Operations/MapReduceOutputToCollectionOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/MapReduceOutputToCollectionOperation.cs
@@ -13,7 +13,6 @@
 * limitations under the License.
 */
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
@@ -142,7 +141,7 @@ namespace MongoDB.Driver.Core.Operations
             var command = base.CreateCommand(session, connectionDescription);
 
             var serverVersion = connectionDescription.ServerVersion;
-            if (_bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion))
+            if (_bypassDocumentValidation.GetValueOrDefault() && Feature.BypassDocumentValidation.IsSupported(serverVersion))
             {
                 command.Add("bypassDocumentValidation", _bypassDocumentValidation.Value);
             }

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableInsertCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableInsertCommandOperation.cs
@@ -115,7 +115,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 { "insert", _collectionNamespace.CollectionName },
                 { "ordered", IsOrdered },
-                { "bypassDocumentValidation", () => _bypassDocumentValidation, _bypassDocumentValidation.HasValue },
+                { "bypassDocumentValidation", () => _bypassDocumentValidation, _bypassDocumentValidation.GetValueOrDefault() },
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "txnNumber", () => transactionNumber.Value, transactionNumber.HasValue }
             };

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryableUpdateCommandOperation.cs
@@ -114,7 +114,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 { "update", _collectionNamespace.CollectionName },
                 { "ordered", IsOrdered },
-                { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.HasValue },
+                { "bypassDocumentValidation", () => _bypassDocumentValidation.Value, _bypassDocumentValidation.GetValueOrDefault() },
                 { "writeConcern", writeConcern, writeConcern != null },
                 { "txnNumber", () => transactionNumber.Value, transactionNumber.HasValue }
             };

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateToCollectionOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/AggregateToCollectionOperationTests.cs
@@ -302,7 +302,7 @@ namespace MongoDB.Driver.Core.Operations
             {
                 { "aggregate", _collectionNamespace.CollectionName },
                 { "pipeline", new BsonArray(__pipeline) },
-                { "bypassDocumentValidation", () => bypassDocumentValidation.Value, bypassDocumentValidation != null && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
+                { "bypassDocumentValidation", () => bypassDocumentValidation.Value, bypassDocumentValidation.GetValueOrDefault() && Feature.BypassDocumentValidation.IsSupported(serverVersion) },
                 { "cursor", new BsonDocument(), serverVersion >= new SemanticVersion(3, 5, 0) }
             };
             result.Should().Be(expectedResult);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndReplaceOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndReplaceOperationTests.cs
@@ -280,7 +280,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "findAndModify", _collectionNamespace.CollectionName },
                 { "query", _filter },
                 { "update", _replacement },
-                { "bypassDocumentValidation", () => value.Value, value.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) }
+                { "bypassDocumentValidation", () => value.Value, value.GetValueOrDefault() && Feature.BypassDocumentValidation.IsSupported(serverVersion) }
             };
             result.Should().Be(expectedResult);
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndUpdateOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/FindOneAndUpdateOperationTests.cs
@@ -274,7 +274,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "findAndModify", _collectionNamespace.CollectionName },
                 { "query", _filter },
                 { "update", _update },
-                { "bypassDocumentValidation", () => bypassDocumentValidation.Value, bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) }
+                { "bypassDocumentValidation", () => bypassDocumentValidation.Value, bypassDocumentValidation.GetValueOrDefault() && Feature.BypassDocumentValidation.IsSupported(serverVersion) }
             };
             result.Should().Be(expectedResult);
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceOutputToCollectionOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceOutputToCollectionOperationTests.cs
@@ -203,7 +203,7 @@ namespace MongoDB.Driver.Core.Operations
                 { "map", _mapFunction },
                 { "reduce", _reduceFunction },
                 { "out", new BsonDocument { {"replace", _outputCollectionNamespace.CollectionName }, { "db", _databaseNamespace.DatabaseName } } },
-                { "bypassDocumentValidation", () => bypassDocumentValidation.Value, bypassDocumentValidation.HasValue && Feature.BypassDocumentValidation.IsSupported(serverVersion) }
+                { "bypassDocumentValidation", () => bypassDocumentValidation.Value, bypassDocumentValidation.GetValueOrDefault() && Feature.BypassDocumentValidation.IsSupported(serverVersion) }
             };
             result.Should().Be(expectedResult);
         }


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5de123433066152c876a5107

NOTE: the spec doesn't say anything about `MapReduceOutputToCollectionOperation` which also has  `BypassDocumentValidation`: https://github.com/mongodb/mongo-csharp-driver/blob/e6e4e58a5133188041ca0a13686451268bdc6124/src/MongoDB.Driver.Core/Core/Operations/MapReduceOutputToCollectionOperation.cs#L147. Should this operation also be updated?