### PR TITLE
CSHARP-2184: Update server selection tests for read preferences with sharded clusters.

### DIFF
--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Nearest.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Nearest.json
@@ -16,7 +16,7 @@
   },
   "operation": "read",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "Nearest",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Nearest.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Nearest.yml
@@ -11,7 +11,7 @@ topology_description:
     type: Mongos
 operation: read
 read_preference:
-  mode: SecondaryPreferred
+  mode: Nearest
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Primary.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Primary.json
@@ -16,12 +16,7 @@
   },
   "operation": "read",
   "read_preference": {
-    "mode": "SecondaryPreferred",
-    "tag_sets": [
-      {
-        "data_center": "nyc"
-      }
-    ]
+    "mode": "Primary"
   },
   "suitable_servers": [
     {

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Primary.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Primary.yml
@@ -11,9 +11,7 @@ topology_description:
     type: Mongos
 operation: read
 read_preference:
-  mode: SecondaryPreferred
-  tag_sets:
-  - data_center: nyc
+  mode: Primary
 suitable_servers:
 - *1
 - *2

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/PrimaryPreferred.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/PrimaryPreferred.json
@@ -16,7 +16,7 @@
   },
   "operation": "read",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "PrimaryPreferred",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/PrimaryPreferred.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/PrimaryPreferred.yml
@@ -11,7 +11,7 @@ topology_description:
     type: Mongos
 operation: read
 read_preference:
-  mode: SecondaryPreferred
+  mode: PrimaryPreferred
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Secondary.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Secondary.json
@@ -16,7 +16,7 @@
   },
   "operation": "read",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "Secondary",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Secondary.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/read/Secondary.yml
@@ -11,7 +11,7 @@ topology_description:
     type: Mongos
 operation: read
 read_preference:
-  mode: SecondaryPreferred
+  mode: Secondary
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Nearest.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Nearest.json
@@ -14,9 +14,9 @@
       }
     ]
   },
-  "operation": "read",
+  "operation": "write",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "Nearest",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Nearest.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Nearest.yml
@@ -9,9 +9,9 @@ topology_description:
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-operation: read
+operation: write
 read_preference:
-  mode: SecondaryPreferred
+  mode: Nearest
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Primary.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Primary.json
@@ -14,14 +14,9 @@
       }
     ]
   },
-  "operation": "read",
+  "operation": "write",
   "read_preference": {
-    "mode": "SecondaryPreferred",
-    "tag_sets": [
-      {
-        "data_center": "nyc"
-      }
-    ]
+    "mode": "Primary"
   },
   "suitable_servers": [
     {

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Primary.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Primary.yml
@@ -9,11 +9,9 @@ topology_description:
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-operation: read
+operation: write
 read_preference:
-  mode: SecondaryPreferred
-  tag_sets:
-  - data_center: nyc
+  mode: Primary
 suitable_servers:
 - *1
 - *2

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/PrimaryPreferred.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/PrimaryPreferred.json
@@ -14,9 +14,9 @@
       }
     ]
   },
-  "operation": "read",
+  "operation": "write",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "PrimaryPreferred",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/PrimaryPreferred.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/PrimaryPreferred.yml
@@ -9,9 +9,9 @@ topology_description:
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-operation: read
+operation: write
 read_preference:
-  mode: SecondaryPreferred
+  mode: PrimaryPreferred
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Secondary.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Secondary.json
@@ -14,9 +14,9 @@
       }
     ]
   },
-  "operation": "read",
+  "operation": "write",
   "read_preference": {
-    "mode": "SecondaryPreferred",
+    "mode": "Secondary",
     "tag_sets": [
       {
         "data_center": "nyc"

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Secondary.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/Secondary.yml
@@ -9,9 +9,9 @@ topology_description:
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-operation: read
+operation: write
 read_preference:
-  mode: SecondaryPreferred
+  mode: Secondary
   tag_sets:
   - data_center: nyc
 suitable_servers:

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/SecondaryPreferred.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/SecondaryPreferred.json
@@ -1,60 +1,45 @@
 {
-    "in_latency_window": [
-        {
-            "address": "g:27017", 
-            "avg_rtt_ms": 5, 
-            "tags": {
-                "data_center": "nyc"
-            }, 
-            "type": "Mongos"
-        }
-    ], 
-    "operation": "write", 
-    "read_preference": {
-        "mode": "SecondaryPreferred", 
-        "tag_sets": [
-            {
-                "data_center": "nyc"
-            }
-        ]
-    }, 
-    "suitable_servers": [
-        {
-            "address": "g:27017", 
-            "avg_rtt_ms": 5, 
-            "tags": {
-                "data_center": "nyc"
-            }, 
-            "type": "Mongos"
-        }, 
-        {
-            "address": "h:27017", 
-            "avg_rtt_ms": 35, 
-            "tags": {
-                "data_center": "dc"
-            }, 
-            "type": "Mongos"
-        }
-    ], 
-    "topology_description": {
-        "servers": [
-            {
-                "address": "g:27017", 
-                "avg_rtt_ms": 5, 
-                "tags": {
-                    "data_center": "nyc"
-                }, 
-                "type": "Mongos"
-            }, 
-            {
-                "address": "h:27017", 
-                "avg_rtt_ms": 35, 
-                "tags": {
-                    "data_center": "dc"
-                }, 
-                "type": "Mongos"
-            }
-        ], 
-        "type": "Sharded"
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 5,
+        "type": "Mongos"
+      },
+      {
+        "address": "h:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "SecondaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      }
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 5,
+      "type": "Mongos"
+    },
+    {
+      "address": "h:27017",
+      "avg_rtt_ms": 35,
+      "type": "Mongos"
     }
+  ],
+  "in_latency_window": [
+    {
+      "address": "g:27017",
+      "avg_rtt_ms": 5,
+      "type": "Mongos"
+    }
+  ]
 }

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/SecondaryPreferred.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-selection/tests/server_selection/Sharded/write/SecondaryPreferred.yml
@@ -1,4 +1,3 @@
----
 topology_description:
   type: Sharded
   servers:
@@ -6,14 +5,10 @@ topology_description:
     address: g:27017
     avg_rtt_ms: 5
     type: Mongos
-    tags:
-      data_center: nyc
   - &2
     address: h:27017
     avg_rtt_ms: 35
     type: Mongos
-    tags:
-      data_center: dc
 operation: write
 read_preference:
   mode: SecondaryPreferred


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5de1416861837d3829e49d2a

NOTE: not 100% sure what does this statement from the ticket description mean: 
    
    Test "secondary" too, at the least, if not all the modes with Sharded.

But it looks like the scope of this ticket is only about syncing tests.