### PR TITLE
CSHARP-2040: Test Driver Wire Version Overlap logic.

### DIFF
--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/TestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/TestRunner.cs
@@ -273,24 +273,18 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         private class TestCaseFactory : JsonDrivenTestCaseFactory
         {
-            #region static
-            private static readonly string[] __ignoredTestNames =
-            {
-                "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring."
-            };
-            #endregion
+            private readonly string __ignoredTestFolder = "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring.";
 
             protected override string PathPrefix => "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.";
 
             protected override IEnumerable<JsonDrivenTestCase> CreateTestCases(BsonDocument document)
             {
                 var path = document["_path"].ToString();
-                if (__ignoredTestNames.Any(i => path.Contains(i)))
+                if (!path.StartsWith(__ignoredTestFolder))
                 {
-                    yield break;
+                    var name = GetTestCaseName(document, document, 0);
+                    yield return new JsonDrivenTestCase(name, document, document);
                 }
-                var name = GetTestCaseName(document, document, 0);
-                yield return new JsonDrivenTestCase(name, document, document);
             }
         }
     }

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/TestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/TestRunner.cs
@@ -14,15 +14,13 @@
 */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
+using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Connections;
@@ -43,9 +41,11 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         [Theory]
         [ClassData(typeof(TestCaseFactory))]
-        public void RunTestDefinition(BsonDocument definition)
+        public void RunTestDefinition(JsonDrivenTestCase testCase)
         {
-            VerifyFields(definition, "description", "path", "phases", "uri");
+            var definition = testCase.Test;
+
+            JsonDrivenHelper.EnsureAllFieldsAreValid(definition, "description", "_path", "phases", "uri");
 
             _cluster = BuildCluster(definition);
             _cluster.Initialize();
@@ -59,7 +59,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         private void ApplyPhase(BsonDocument phase)
         {
-            VerifyFields(phase, "outcome", "responses");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(phase, "outcome", "responses");
 
             var responses = phase["responses"].AsBsonArray;
             foreach (BsonArray response in responses)
@@ -80,7 +80,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
             var address = response[0].AsString;
             var isMasterDocument = response[1].AsBsonDocument;
-            VerifyFields(isMasterDocument, "arbiterOnly", "arbiters", "electionId", "hidden", "hosts", "ismaster", "isreplicaset", "logicalSessionTimeoutMinutes", "maxWireVersion", "me", "minWireVersion", "msg", "ok", "passive", "passives", "primary", "secondary", "setName", "setVersion");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(isMasterDocument, "arbiterOnly", "arbiters", "electionId", "hidden", "hosts", "ismaster", "isreplicaset", "logicalSessionTimeoutMinutes", "maxWireVersion", "me", "minWireVersion", "msg", "ok", "passive", "passives", "primary", "secondary", "setName", "setVersion");
 
             var endPoint = EndPointHelper.Parse(address);
             var isMasterResult = new IsMasterResult(isMasterDocument);
@@ -97,17 +97,6 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
             var currentClusterDescription = _cluster.Description;
             _serverFactory.PublishDescription(newServerDescription);
             SpinWait.SpinUntil(() => !object.ReferenceEquals(_cluster.Description, currentClusterDescription), 100); // sometimes returns false and that's OK
-        }
-
-        private void VerifyFields(BsonDocument document, params string[] expectedNames)
-        {
-            foreach (var name in document.Names)
-            {
-                if (!expectedNames.Contains(name))
-                {
-                    throw new FormatException($"Invalid field: \"{name}\".");
-                }
-            }
         }
 
         private void VerifyTopology(ICluster cluster, string expectedType)
@@ -141,7 +130,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         private void VerifyOutcome(BsonDocument outcome)
         {
-            VerifyFields(outcome, "compatible", "logicalSessionTimeoutMinutes", "servers", "setName", "topologyType");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(outcome, "compatible", "logicalSessionTimeoutMinutes", "servers", "setName", "topologyType");
 
             var expectedTopologyType = (string)outcome["topologyType"];
             VerifyTopology(_cluster, expectedTopologyType);
@@ -194,7 +183,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         private void VerifyServerDescription(ServerDescription actualDescription, BsonDocument expectedDescription)
         {
-            VerifyFields(expectedDescription, "electionId", "setName", "setVersion", "type");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(expectedDescription, "electionId", "setName", "setVersion", "type");
 
             var expectedType = (string)expectedDescription["type"];
             switch (expectedType)
@@ -282,38 +271,26 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
                 .CreateCluster();
         }
 
-        private class TestCaseFactory : IEnumerable<object[]>
+        private class TestCaseFactory : JsonDrivenTestCaseFactory
         {
-            public IEnumerator<object[]> GetEnumerator()
+            #region static
+            private static readonly string[] __ignoredTestNames =
             {
-                const string prefix = "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.";
-                const string monitoringPrefix = "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring.";
-                var executingAssembly = typeof(TestCaseFactory).GetTypeInfo().Assembly;
-                var enumerable = executingAssembly
-                    .GetManifestResourceNames()
-                    .Where(path => path.StartsWith(prefix) && path.EndsWith(".json"))
-                    .Where(path => !path.StartsWith(monitoringPrefix))
-                    .Select(path => ReadDefinition(path))
-                    .Select(definition => new object[] { definition });
-                return enumerable.GetEnumerator();
-            }
+                "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring."
+            };
+            #endregion
 
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
+            protected override string PathPrefix => "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.";
 
-            private static BsonDocument ReadDefinition(string path)
+            protected override IEnumerable<JsonDrivenTestCase> CreateTestCases(BsonDocument document)
             {
-                var executingAssembly = typeof(TestCaseFactory).GetTypeInfo().Assembly;
-                using (var definitionStream = executingAssembly.GetManifestResourceStream(path))
-                using (var definitionStringReader = new StreamReader(definitionStream))
+                var path = document["_path"].ToString();
+                if (__ignoredTestNames.Any(i => path.Contains(i)))
                 {
-                    var definitionString = definitionStringReader.ReadToEnd();
-                    var definition = BsonDocument.Parse(definitionString);
-                    definition.InsertAt(0, new BsonElement("path", path));
-                    return definition;
+                    yield break;
                 }
+                var name = GetTestCaseName(document, document, 0);
+                yield return new JsonDrivenTestCase(name, document, document);
             }
         }
     }

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/README.rst
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/README.rst
@@ -9,14 +9,8 @@ Server Discovery And Monitoring Spec.
 Version
 -------
 
-Files in the "specifications" repository have no version scheme.
-They are not tied to a MongoDB server version,
-and it is our intention that each specification moves from "draft" to "final"
-with no further versions; it is superseded by a future spec, not revised.
-
-However, implementers must have stable sets of tests to target.
-As test files evolve they will be occasionally tagged like
-"server-discovery-tests-2014-09-10", until the spec is final.
+Files in the "specifications" repository have no version scheme. They are not
+tied to a MongoDB server version.
 
 Format
 ------

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_becomes_ghost.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_becomes_ghost.json
@@ -1,0 +1,59 @@
+{
+  "description": "Primary becomes ghost",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "isreplicaset": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSGhost",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_becomes_ghost.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_becomes_ghost.yml
@@ -1,0 +1,63 @@
+description: "Primary becomes ghost"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    hosts: ["a:27017"],
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: false,
+                    isreplicaset: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSGhost",
+                    setName:
+                }
+            },
+            topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_becomes_mongos.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_becomes_mongos.json
@@ -1,0 +1,54 @@
+{
+  "description": "Primary becomes mongos",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "msg": "isdbgrid",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {},
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_becomes_mongos.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_becomes_mongos.yml
@@ -1,0 +1,56 @@
+description: "Primary becomes mongos"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    hosts: ["a:27017"],
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {},
+            topologyType: "ReplicaSetNoPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_mismatched_me.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_mismatched_me.json
@@ -28,7 +28,9 @@
             ],
             "ismaster": true,
             "ok": 1,
-            "setName": "rs"
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
           }
         ]
       ]

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_mismatched_me.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/primary_mismatched_me.yml
@@ -20,5 +20,7 @@ phases:
           ismaster: true
           ok: 1
           setName: rs
+          minWireVersion: 0
+          maxWireVersion: 6
 uri: 'mongodb://localhost:27017/?replicaSet=rs'
 

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.json
@@ -1,0 +1,81 @@
+{
+  "description": "New primary",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 0,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.yml
@@ -1,0 +1,85 @@
+description: "New primary"
+
+uri: "mongodb://a,b/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 0,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/secondary_mismatched_me.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/secondary_mismatched_me.json
@@ -28,7 +28,9 @@
             ],
             "ismaster": false,
             "ok": 1,
-            "setName": "rs"
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
           }
         ]
       ]

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/secondary_mismatched_me.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/secondary_mismatched_me.yml
@@ -20,5 +20,7 @@ phases:
           ismaster: false
           ok: 1
           setName: rs
+          minWireVersion: 0
+          maxWireVersion: 6
 uri: 'mongodb://localhost:27017/?replicaSet=rs'
 


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5de6b21c0ae6066caeb2fe2e

This ticket contains only syncing JSON tests and small refactoring for the test runner.

NOTE1: I've also tried to implement this SPEC tests: https://jira.mongodb.org/browse/SPEC-1171 but with no luck. Some tests failed. Since this spec change is not in the scope of the current CSHARP ticket, I give up to implement it now.

NOTE2: I assume that `clientMinWireVersion` and `clientMaxWireVersion` are the same values as c# driver defines in this line https://github.com/mongodb/mongo-csharp-driver/blob/master/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs#L43