### PR TITLE
CSHARP-2861: Having incorrect credentials along with minPoolSize > 0 makes the driver to endlessly create new connections..

### DIFF
--- a/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
+++ b/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
@@ -321,7 +321,16 @@ namespace MongoDB.Driver.Core.ConnectionPools
                     // when adding in a connection, we need to open it because 
                     // the whole point of having a min pool size is to have
                     // them available and ready...
-                    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (MongoAuthenticationException)
+                    {
+                        // if connection fails with MongoAuthenticationException we should close the socket
+                        connection.Dispose();
+                        throw;
+                    }
                     _connectionHolder.Return(connection);
                     stopwatch.Stop();
 

--- a/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
+++ b/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
@@ -258,13 +258,13 @@ namespace MongoDB.Driver.Core.ConnectionPools
                 {
                     await PrunePoolAsync(maintenanceCancellationToken).ConfigureAwait(false);
                     await EnsureMinSizeAsync(maintenanceCancellationToken).ConfigureAwait(false);
-                    await Task.Delay(_settings.MaintenanceInterval, maintenanceCancellationToken).ConfigureAwait(false);
                 }
                 catch
                 {
                     // do nothing, this is called in the background and, quite frankly, should never
                     // result in an error
                 }
+                await Task.Delay(_settings.MaintenanceInterval, maintenanceCancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
+++ b/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
@@ -325,9 +325,8 @@ namespace MongoDB.Driver.Core.ConnectionPools
                     {
                         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
                     }
-                    catch (MongoAuthenticationException)
+                    catch (Exception)
                     {
-                        // if connection fails with MongoAuthenticationException we should close the socket
                         connection.Dispose();
                         throw;
                     }

--- a/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
+++ b/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs
@@ -261,8 +261,7 @@ namespace MongoDB.Driver.Core.ConnectionPools
                 }
                 catch
                 {
-                    // do nothing, this is called in the background and, quite frankly, should never
-                    // result in an error
+                    // ignore exceptions
                 }
                 await Task.Delay(_settings.MaintenanceInterval, maintenanceCancellationToken).ConfigureAwait(false);
             }

--- a/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
@@ -472,7 +472,7 @@ namespace MongoDB.Driver.Core.ConnectionPools
                     .Throws<Exception>()    // failed attempt
                     .Returns(() =>          // successful attempt which should be delayed
                     {
-                        // break the loop. with this line the MaintainSizeAsync loop will contain only 2 iteration
+                        // break the loop. With this line the MaintainSizeAsync will contain only 2 iterations
                         subject._maintenanceCancellationTokenSource().Cancel();
                         return new MockConnection(_serverId);
                     });

--- a/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
@@ -17,7 +17,9 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
+using MongoDB.Bson.TestHelpers;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
@@ -62,12 +64,7 @@ namespace MongoDB.Driver.Core.ConnectionPools
                 waitQueueSize: 1,
                 waitQueueTimeout: TimeSpan.FromSeconds(2));
 
-            _subject = new ExclusiveConnectionPool(
-                _serverId,
-                _endPoint,
-                _settings,
-                _mockConnectionFactory.Object,
-                _capturedEvents);
+            _subject = CreateSubject();
         }
 
         [Fact]
@@ -463,6 +460,42 @@ namespace MongoDB.Driver.Core.ConnectionPools
             }
         }
 
+        [Fact]
+        public void MaintainSizeAsync_should_not_try_new_attempt_after_failing_without_delay()
+        {
+            var settings =_settings.With(maintenanceInterval: TimeSpan.FromSeconds(10));
+
+            using (var subject = CreateSubject(settings))
+            {
+                _mockConnectionFactory
+                    .SetupSequence(f => f.CreateConnection(_serverId, _endPoint))
+                    .Throws<Exception>()    // failed attempt
+                    .Returns(() =>          // successful attempt which should be delayed
+                    {
+                        // break the loop. with this line the MaintainSizeAsync loop will contain only 2 iteration
+                        subject._maintenanceCancellationTokenSource().Cancel();
+                        return new MockConnection(_serverId);
+                    });
+
+                var testResult = Task.WaitAny(
+                    subject.MaintainSizeAsync(),            // if this task is completed first, it will mean that there was no delay (10 sec) 
+                    Task.Delay(TimeSpan.FromSeconds(1)));   // time to be sure that delay is happening,
+                                                            // if the method is running more than 1 second, then delay is happening
+                testResult.Should().Be(1);
+            }
+        }
+
+        // private methods
+        private ExclusiveConnectionPool CreateSubject(ConnectionPoolSettings connectionPoolSettings = null)
+        {
+            return new ExclusiveConnectionPool(
+                _serverId,
+                _endPoint,
+                connectionPoolSettings ?? _settings,
+                _mockConnectionFactory.Object,
+                _capturedEvents);
+        }
+
         private void InitializeAndWait()
         {
             _subject.Initialize();
@@ -479,6 +512,19 @@ namespace MongoDB.Driver.Core.ConnectionPools
             _subject.CreatedCount.Should().Be(_settings.MinConnections);
             _subject.DormantCount.Should().Be(_settings.MinConnections);
             _subject.UsedCount.Should().Be(0);
+        }
+    }
+
+    internal static class ExclusiveConnectionPoolReflector
+    {
+        public static CancellationTokenSource _maintenanceCancellationTokenSource(this ExclusiveConnectionPool obj)
+        {
+            return (CancellationTokenSource)Reflector.GetFieldValue(obj, nameof(_maintenanceCancellationTokenSource));
+        }
+
+        public static Task MaintainSizeAsync(this ExclusiveConnectionPool obj)
+        {
+            return (Task)Reflector.Invoke(obj, nameof(MaintainSizeAsync));
         }
     }
 }


### PR DESCRIPTION
EG:   https://evergreen.mongodb.com/version/5dee7f693e8e8629004929d4

**NOTE**: Sounds like there is no way to have unclosed sockets in case if opening connection fails. I've added a test to check it: https://github.com/DmitryLukyanov/mongo-csharp-driver/pull/92/files#diff-462741f8dce658fd58f4f6dd2699ab02R36

The methods where sockets are disposed:
 - `TcpStreamFactory`: https://github.com/DmitryLukyanov/mongo-csharp-driver/blob/master/src/MongoDB.Driver.Core/Core/Connections/TcpStreamFactory.cs#L169
 - `SslStreamFactory`: https://github.com/DmitryLukyanov/mongo-csharp-driver/blob/master/src/MongoDB.Driver.Core/Core/Connections/SslStreamFactory.cs#L77

**NOTE2**: If I understood the java implementation correctly, java has a little bit different implementation of this logic: https://github.com/mongodb/mongo-csharp-driver/blob/master/src/MongoDB.Driver.Core/Core/ConnectionPools/ExclusiveConnectionPool.cs#L255

In case if `EnsureMinSizeAsync` attempt fails, `java` doesn't start a new attempt immediately, only after 1 min delay, in the `c#` we'are trying to make new attempts right after failing. So, it means that for the case when we provide wrong credentials, we will keep trying to create new connections all the time.

I've implemented the possible fix for it and related test: https://github.com/DmitryLukyanov/mongo-csharp-driver/pull/92/files#diff-6217848c52f25851ca783e0d424c8160R267
Not 100% that it's required, we can discuss it.

**UPDATE:**
**NOTE3**:  The previous implementation didn't close a socket when authentication has failed. The **NOTE1** above tells that we will always close sockets during opening connections, but authentication error will be triggered in the next step after opening. So, in that case, opening by itself is successful, but the authentication attempt failed. 


