### PR TITLE
CSHARP-2869: Update FLE documentation for community version demonstrating explicit encryption/decryption.

### DIFF
--- a/Docs/reference/content/reference/driver/crud/client_side_encryption.md
+++ b/Docs/reference/content/reference/driver/crud/client_side_encryption.md
@@ -40,6 +40,8 @@ documentation.
 
 ## Examples
 
+### Automatic client-side encryption
+
 The following is a sample app that assumes the **key** and **schema** have
 already been created in MongoDB. The example uses a local key, however using AWS
 Key Management Service is also an option. The data in the `encryptedField` field
@@ -209,7 +211,7 @@ namespace MongoDB.Driver.Examples
             kmsProviders.Add("local", localKey);
 
             var keyVaultNamespace = CollectionNamespace.FromFullName("admin.datakeys");
-            var keyVaultClient = new MongoClient();
+            var keyVaultClient = new MongoClient("mongodb://localhost");
             var keyVaultDatabase = keyVaultClient.GetDatabase(keyVaultNamespace.DatabaseNamespace.DatabaseName);
             keyVaultDatabase.DropCollection(keyVaultNamespace.CollectionName);
 
@@ -282,16 +284,14 @@ namespace MongoDB.Driver.Examples
                 keyVaultNamespace,
                 kmsProviders,
                 bypassAutoEncryption: true);
-            var clientSettings = new MongoClientSettings
-            {
-                AutoEncryptionOptions = autoEncryptionOptions,
-            };
+            var clientSettings = MongoClientSettings.FromConnectionString("mongodb://localhost");
+            clientSettings.AutoEncryptionOptions = autoEncryptionOptions;
             var mongoClient = new MongoClient(clientSettings);
             var database = mongoClient.GetDatabase(collectionNamespace.DatabaseNamespace.DatabaseName);
             database.DropCollection(collectionNamespace.CollectionName);
             var collection = database.GetCollection<BsonDocument>(collectionNamespace.CollectionName);
 
-            var keyVaultClient = new MongoClient();
+            var keyVaultClient = new MongoClient("mongodb://localhost");
             var keyVaultDatabase = keyVaultClient.GetDatabase(keyVaultNamespace.DatabaseNamespace.DatabaseName);
             keyVaultDatabase.DropCollection(keyVaultNamespace.CollectionName);
 

--- a/Docs/reference/content/reference/driver/crud/client_side_encryption.md
+++ b/Docs/reference/content/reference/driver/crud/client_side_encryption.md
@@ -181,4 +181,155 @@ namespace MongoDB.Driver.Examples
 }
 ```
 
-**Coming soon:** An example using the community version and demonstrating explicit encryption/decryption.
+### Explicit Encryption and Decryption
+
+Explicit encryption and decryption is a **MongoDB community** feature and does not use the `mongocryptd` process. Explicit encryption is provided by the `ClientEncryption` class. 
+The following example has been adapted from [`ExplicitEncryptionExamples.cs`](https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs):
+
+```
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using MongoDB.Driver.Encryption;
+using MongoDB.Libmongocrypt;
+
+namespace MongoDB.Driver.Examples
+{
+    public class ExplicitEncryptionExamples
+    {
+        private const string LocalMasterKey = "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk";
+
+        public static void Main(string[] args)
+        {
+            var localMasterKey = Convert.FromBase64String(LocalMasterKey);
+            var kmsProviders = new Dictionary<string, IReadOnlyDictionary<string, object>>();
+            var localKey = new Dictionary<string, object>
+            {
+                { "key", localMasterKey }
+            };
+            kmsProviders.Add("local", localKey);
+
+            var keyVaultNamespace = CollectionNamespace.FromFullName("admin.datakeys");
+            var keyVaultClient = new MongoClient();
+            var keyVaultDatabase = keyVaultClient.GetDatabase(keyVaultNamespace.DatabaseNamespace.DatabaseName);
+            keyVaultDatabase.DropCollection(keyVaultNamespace.CollectionName);
+
+            // Create the ClientEncryption instance
+            var clientEncryptionSettings = new ClientEncryptionOptions(
+                keyVaultClient,
+                keyVaultNamespace,
+                kmsProviders);
+            var clientEncryption = new ClientEncryption(clientEncryptionSettings);
+
+            var dataKeyId = clientEncryption.CreateDataKey(
+                "local",
+                new DataKeyOptions(),
+                CancellationToken.None);
+
+            var originalString = "123456789";
+            Console.WriteLine($"Original string {originalString}.");
+
+            // Explicitly encrypt a field
+            var encryptOptions = new EncryptOptions(
+                EncryptionAlgorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic.ToString(),
+                keyId: dataKeyId);
+            var encryptedFieldValue = clientEncryption.Encrypt(
+                originalString,
+                encryptOptions,
+                CancellationToken.None);
+            Console.WriteLine($"Encrypted value {encryptedFieldValue}.");
+
+            // Explicitly decrypt the field
+            var decryptedValue = clientEncryption.Decrypt(encryptedFieldValue, CancellationToken.None);
+            Console.WriteLine($"Decrypted value {decryptedValue}.");
+
+            clientEncryption.Dispose();
+        }
+    }
+}
+```
+
+### Explicit Encryption and Auto Decryption
+
+Although automatic encryption requires MongoDB 4.2 enterprise or a MongoDB 4.2 Atlas cluster, automatic decryption is supported for all 
+users. To configure automatic decryption without automatic encryption set `bypassAutoEncryption=true`. The following example has been adapted from [`ExplicitEncryptionExamples.cs`](https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs):
+
+```
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using MongoDB.Bson;
+using MongoDB.Driver.Encryption;
+using MongoDB.Libmongocrypt;
+
+namespace MongoDB.Driver.Examples
+{
+    public class ExplicitEncryptionAndAutoDecryptionExamples
+    {
+        private const string LocalMasterKey = "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk";
+
+        public static void Main(string[] args)
+        {
+            var localMasterKey = Convert.FromBase64String(LocalMasterKey);
+            var kmsProviders = new Dictionary<string, IReadOnlyDictionary<string, object>>();
+            var localKey = new Dictionary<string, object>
+            {
+                { "key", localMasterKey }
+            };
+            kmsProviders.Add("local", localKey);
+
+            var keyVaultNamespace = CollectionNamespace.FromFullName("admin.datakeys");
+            var collectionNamespace = CollectionNamespace.FromFullName("test.coll");
+            var autoEncryptionOptions = new AutoEncryptionOptions(
+                keyVaultNamespace,
+                kmsProviders,
+                bypassAutoEncryption: true);
+            var clientSettings = new MongoClientSettings
+            {
+                AutoEncryptionOptions = autoEncryptionOptions,
+            };
+            var mongoClient = new MongoClient(clientSettings);
+            var database = mongoClient.GetDatabase(collectionNamespace.DatabaseNamespace.DatabaseName);
+            database.DropCollection(collectionNamespace.CollectionName);
+            var collection = database.GetCollection<BsonDocument>(collectionNamespace.CollectionName);
+
+            var keyVaultClient = new MongoClient();
+            var keyVaultDatabase = keyVaultClient.GetDatabase(keyVaultNamespace.DatabaseNamespace.DatabaseName);
+            keyVaultDatabase.DropCollection(keyVaultNamespace.CollectionName);
+
+            // Create the ClientEncryption instance
+            var clientEncryptionSettings = new ClientEncryptionOptions(
+                keyVaultClient,
+                keyVaultNamespace,
+                kmsProviders);
+            var clientEncryption = new ClientEncryption(clientEncryptionSettings);
+
+            var dataKeyId = clientEncryption.CreateDataKey(
+                "local",
+                new DataKeyOptions(),
+                CancellationToken.None);
+
+            var originalString = "123456789";
+            Console.WriteLine($"Original string {originalString}.");
+
+            // Explicitly encrypt a field
+            var encryptOptions = new EncryptOptions(
+                EncryptionAlgorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic.ToString(),
+                keyId: dataKeyId);
+            var encryptedFieldValue = clientEncryption.Encrypt(
+                originalString,
+                encryptOptions,
+                CancellationToken.None);
+            Console.WriteLine($"Encrypted value {encryptedFieldValue}.");
+
+            collection.InsertOne(new BsonDocument("encryptedField", encryptedFieldValue));
+
+            // Automatically decrypts the encrypted field.
+            var decryptedValue = collection.Find(FilterDefinition<BsonDocument>.Empty).First();
+            Console.WriteLine($"Decrypted document {decryptedValue.ToJson()}.");
+
+            clientEncryption.Dispose();
+        }
+    }
+}
+```

--- a/Docs/reference/content/reference/driver/crud/client_side_encryption.md
+++ b/Docs/reference/content/reference/driver/crud/client_side_encryption.md
@@ -183,8 +183,7 @@ namespace MongoDB.Driver.Examples
 
 ### Explicit Encryption and Decryption
 
-Explicit encryption and decryption is a **MongoDB community** feature and does not use the `mongocryptd` process. Explicit encryption is provided by the `ClientEncryption` class. 
-The following example has been adapted from [`ExplicitEncryptionExamples.cs`](https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs):
+Explicit encryption and decryption is a **MongoDB community** feature and does not use the `mongocryptd` process. Explicit encryption is provided by the `ClientEncryption` class. The following example has been adapted from [`ExplicitEncryptionExamples.cs`](https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs):
 
 ```
 using System;
@@ -251,8 +250,7 @@ namespace MongoDB.Driver.Examples
 
 ### Explicit Encryption and Auto Decryption
 
-Although automatic encryption requires MongoDB 4.2 enterprise or a MongoDB 4.2 Atlas cluster, automatic decryption is supported for all 
-users. To configure automatic decryption without automatic encryption set `bypassAutoEncryption=true`. The following example has been adapted from [`ExplicitEncryptionExamples.cs`](https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs):
+Although automatic encryption requires MongoDB 4.2 enterprise or a MongoDB 4.2 Atlas cluster, automatic decryption is supported for all users. To configure automatic decryption without automatic encryption set `bypassAutoEncryption=true`. The following example has been adapted from [`ExplicitEncryptionExamples.cs`](https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs):
 
 ```
 using System;

--- a/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs
+++ b/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs
@@ -52,7 +52,7 @@ namespace MongoDB.Driver.Examples
             kmsProviders.Add("local", localKey);
 
             var keyVaultNamespace = CollectionNamespace.FromFullName("admin.datakeys");
-            var keyVaultClient = new MongoClient();
+            var keyVaultClient = new MongoClient("mongodb://localhost");
             var keyVaultDatabase = keyVaultClient.GetDatabase(keyVaultNamespace.DatabaseNamespace.DatabaseName);
             keyVaultDatabase.DropCollection(keyVaultNamespace.CollectionName);
 
@@ -108,16 +108,14 @@ namespace MongoDB.Driver.Examples
                 keyVaultNamespace,
                 kmsProviders,
                 bypassAutoEncryption: true);
-            var clientSettings = new MongoClientSettings
-            {
-                AutoEncryptionOptions = autoEncryptionOptions,
-            };
+            var clientSettings = MongoClientSettings.FromConnectionString("mongodb://localhost");
+            clientSettings.AutoEncryptionOptions = autoEncryptionOptions;
             var mongoClient = new MongoClient(clientSettings);
             var database = mongoClient.GetDatabase(collectionNamespace.DatabaseNamespace.DatabaseName);
             database.DropCollection(collectionNamespace.CollectionName);
             var collection = database.GetCollection<BsonDocument>(collectionNamespace.CollectionName);
 
-            var keyVaultClient = new MongoClient();
+            var keyVaultClient = new MongoClient("mongodb://localhost");
             var keyVaultDatabase = keyVaultClient.GetDatabase(keyVaultNamespace.DatabaseNamespace.DatabaseName);
             keyVaultDatabase.DropCollection(keyVaultNamespace.CollectionName);
 

--- a/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs
+++ b/tests/MongoDB.Driver.Examples/ExplicitEncryptionExamples.cs
@@ -1,0 +1,158 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using MongoDB.Bson;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using MongoDB.Driver.Encryption;
+using MongoDB.Libmongocrypt;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MongoDB.Driver.Examples
+{
+    public class ExplicitEncryptionExamples
+    {
+        private const string LocalMasterKey = "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk";
+
+        private readonly ITestOutputHelper _output;
+
+        public ExplicitEncryptionExamples(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void ClientSideExplicitEncryptionAndDecryptionTour()
+        {
+            RequireServer.Check().Supports(Feature.ClientSideEncryption);
+
+            var localMasterKey = Convert.FromBase64String(LocalMasterKey);
+
+            var kmsProviders = new Dictionary<string, IReadOnlyDictionary<string, object>>();
+            var localKey = new Dictionary<string, object>
+            {
+                { "key", localMasterKey }
+            };
+            kmsProviders.Add("local", localKey);
+
+            var keyVaultNamespace = CollectionNamespace.FromFullName("admin.datakeys");
+            var keyVaultClient = new MongoClient();
+            var keyVaultDatabase = keyVaultClient.GetDatabase(keyVaultNamespace.DatabaseNamespace.DatabaseName);
+            keyVaultDatabase.DropCollection(keyVaultNamespace.CollectionName);
+
+            // Create the ClientEncryption instance
+            var clientEncryptionSettings = new ClientEncryptionOptions(
+                keyVaultClient,
+                keyVaultNamespace,
+                kmsProviders);
+            var clientEncryption = new ClientEncryption(clientEncryptionSettings);
+
+            var dataKeyId = clientEncryption.CreateDataKey(
+                "local",
+                new DataKeyOptions(),
+                CancellationToken.None);
+
+            var originalString = "123456789";
+            _output.WriteLine($"Original string {originalString}.");
+
+            // Explicitly encrypt a field
+            var encryptOptions = new EncryptOptions(
+                EncryptionAlgorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic.ToString(),
+                keyId: dataKeyId);
+            var encryptedFieldValue = clientEncryption.Encrypt(
+                originalString,
+                encryptOptions,
+                CancellationToken.None);
+            _output.WriteLine($"Encrypted value {encryptedFieldValue}.");
+
+            // Explicitly decrypt the field
+            var decryptedValue = clientEncryption.Decrypt(encryptedFieldValue, CancellationToken.None);
+            _output.WriteLine($"Decrypted value {decryptedValue}.");
+
+            clientEncryption.Dispose();
+        }
+
+        [Fact]
+        public void ClientSideExplicitEncryptionAndAutoDecryptionTour()
+        {
+            RequireServer.Check().Supports(Feature.ClientSideEncryption);
+
+            var localMasterKey = Convert.FromBase64String(LocalMasterKey);
+
+            var kmsProviders = new Dictionary<string, IReadOnlyDictionary<string, object>>();
+            var localKey = new Dictionary<string, object>
+            {
+                { "key", localMasterKey }
+            };
+            kmsProviders.Add("local", localKey);
+
+            var keyVaultNamespace = CollectionNamespace.FromFullName("admin.datakeys");
+            var collectionNamespace = CollectionNamespace.FromFullName("test.coll");
+            var autoEncryptionOptions = new AutoEncryptionOptions(
+                keyVaultNamespace,
+                kmsProviders,
+                bypassAutoEncryption: true);
+            var clientSettings = new MongoClientSettings
+            {
+                AutoEncryptionOptions = autoEncryptionOptions,
+            };
+            var mongoClient = new MongoClient(clientSettings);
+            var database = mongoClient.GetDatabase(collectionNamespace.DatabaseNamespace.DatabaseName);
+            database.DropCollection(collectionNamespace.CollectionName);
+            var collection = database.GetCollection<BsonDocument>(collectionNamespace.CollectionName);
+
+            var keyVaultClient = new MongoClient();
+            var keyVaultDatabase = keyVaultClient.GetDatabase(keyVaultNamespace.DatabaseNamespace.DatabaseName);
+            keyVaultDatabase.DropCollection(keyVaultNamespace.CollectionName);
+
+            // Create the ClientEncryption instance
+            var clientEncryptionSettings = new ClientEncryptionOptions(
+                keyVaultClient,
+                keyVaultNamespace,
+                kmsProviders);
+            var clientEncryption = new ClientEncryption(clientEncryptionSettings);
+
+            var dataKeyId = clientEncryption.CreateDataKey(
+                "local",
+                new DataKeyOptions(),
+                CancellationToken.None);
+
+            var originalString = "123456789";
+            _output.WriteLine($"Original string {originalString}.");
+
+            // Explicitly encrypt a field
+            var encryptOptions = new EncryptOptions(
+                EncryptionAlgorithm.AEAD_AES_256_CBC_HMAC_SHA_512_Deterministic.ToString(),
+                keyId: dataKeyId);
+            var encryptedFieldValue = clientEncryption.Encrypt(
+                originalString,
+                encryptOptions,
+                CancellationToken.None);
+            _output.WriteLine($"Encrypted value {encryptedFieldValue}.");
+
+            collection.InsertOne(new BsonDocument("encryptedField", encryptedFieldValue));
+
+            // Automatically decrypts the encrypted field.
+            var decryptedValue = collection.Find(FilterDefinition<BsonDocument>.Empty).First();
+            _output.WriteLine($"Decrypted document {decryptedValue.ToJson()}.");
+
+            clientEncryption.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
I took java implementation as an example: https://github.com/mongodb/mongo-java-driver/commit/3835b1416f15745541991b55ecd8321fa7ddd8fa