### PR TITLE
CSHARP-2592: Add .NET Standard 2.0 support.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -15,8 +15,6 @@ var gitVersion = GitVersion();
 var solutionDirectory = MakeAbsolute(Directory("./"));
 var artifactsDirectory = solutionDirectory.Combine("artifacts");
 var artifactsBinDirectory = artifactsDirectory.Combine("bin");
-var artifactsBinNet452Directory = artifactsBinDirectory.Combine("net452");
-var artifactsBinNetStandard15Directory = artifactsBinDirectory.Combine("netstandard1.5");
 var artifactsDocsDirectory = artifactsDirectory.Combine("docs");
 var artifactsDocsApiDocsDirectory = artifactsDocsDirectory.Combine("ApiDocs-" + gitVersion.LegacySemVer);
 var artifactsDocsRefDocsDirectory = artifactsDocsDirectory.Combine("RefDocs-" + gitVersion.LegacySemVer);
@@ -75,7 +73,7 @@ Task("BuildArtifacts")
     .IsDependentOn("Build")
     .Does(() =>
     {
-        foreach (var targetFramework in new[] { "net452", "netstandard1.5" })
+        foreach (var targetFramework in new[] { "net452", "netstandard1.5", "netstandard2.0" })
         {
             var toDirectory = artifactsBinDirectory.Combine(targetFramework);
             CleanDirectory(toDirectory);

--- a/src/MongoDB.Bson/MongoDB.Bson.csproj
+++ b/src/MongoDB.Bson/MongoDB.Bson.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
+++ b/src/MongoDB.Bson/Serialization/Serializers/BsonClassMapSerializer.cs
@@ -15,7 +15,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET452 || NETSTANDARD2_0
 using System.ComponentModel;
+#endif
 using System.Linq;
 using System.Reflection;
 using MongoDB.Bson.IO;
@@ -155,7 +157,7 @@ namespace MongoDB.Bson.Serialization
 
             Dictionary<string, object> values = null;
             var document = default(TClass);
-#if NET452
+#if NET452 || NETSTANDARD2_0
             ISupportInitialize supportsInitialization = null;
 #endif
             if (_classMap.HasCreatorMaps)
@@ -168,7 +170,7 @@ namespace MongoDB.Bson.Serialization
                 // for mutable classes we deserialize the values directly into the result object
                 document = (TClass)_classMap.CreateInstance();
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
                 supportsInitialization = document as ISupportInitialize;
                 if (supportsInitialization != null)
                 {
@@ -319,7 +321,7 @@ namespace MongoDB.Bson.Serialization
 
             if (document != null)
             {
-#if NET452
+#if NET452 || NETSTANDARD2_0
                 if (supportsInitialization != null)
                 {
                     supportsInitialization.EndInit();
@@ -471,7 +473,7 @@ namespace MongoDB.Bson.Serialization
             var creatorMap = ChooseBestCreator(values);
             var document = creatorMap.CreateInstance(values); // removes values consumed
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
             var supportsInitialization = document as ISupportInitialize;
             if (supportsInitialization != null)
             {
@@ -491,7 +493,7 @@ namespace MongoDB.Bson.Serialization
                 }
             }
 
-#if NET452
+#if NET452 || NETSTANDARD2_0
             if (supportsInitialization != null)
             {
                 supportsInitialization.EndInit();

--- a/src/MongoDB.Bson/TargetFramework.cs
+++ b/src/MongoDB.Bson/TargetFramework.cs
@@ -1,0 +1,29 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Bson
+{
+    internal static class TargetFramework
+    {
+        public static string Moniker =>
+#if NET452
+            "net452";
+#elif NETSTANDARD1_5
+            "netstandard15";
+#elif NETSTANDARD2_0
+            "netstandard20";
+#endif
+    }
+}

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/MongoDB.Driver.Core/TargetFramework.cs
+++ b/src/MongoDB.Driver.Core/TargetFramework.cs
@@ -1,0 +1,29 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.Core
+{
+    internal static class TargetFramework
+    {
+        public static string Moniker =>
+#if NET452
+            "net452";
+#elif NETSTANDARD1_5
+            "netstandard15";
+#elif NETSTANDARD2_0
+            "netstandard20";
+#endif
+    }
+}

--- a/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
+++ b/src/MongoDB.Driver.GridFS/MongoDB.Driver.GridFS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/MongoDB.Driver.GridFS/TargetFramework.cs
+++ b/src/MongoDB.Driver.GridFS/TargetFramework.cs
@@ -1,0 +1,29 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.GridFS
+{
+    internal static class TargetFramework
+    {
+        public static string Moniker =>
+#if NET452
+            "net452";
+#elif NETSTANDARD1_5
+            "netstandard15";
+#elif NETSTANDARD2_0
+            "netstandard20";
+#endif
+    }
+}

--- a/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
+++ b/src/MongoDB.Driver.Legacy/MongoDB.Driver.Legacy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/MongoDB.Driver.Legacy/TargetFramework.cs
+++ b/src/MongoDB.Driver.Legacy/TargetFramework.cs
@@ -1,0 +1,29 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver.Legacy
+{
+    internal static class TargetFramework
+    {
+        public static string Moniker =>
+#if NET452
+            "net452";
+#elif NETSTANDARD1_5
+            "netstandard15";
+#elif NETSTANDARD2_0
+            "netstandard20";
+#endif
+    }
+}

--- a/src/MongoDB.Driver/MongoDB.Driver.csproj
+++ b/src/MongoDB.Driver/MongoDB.Driver.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/src/MongoDB.Driver/TargetFramework.cs
+++ b/src/MongoDB.Driver/TargetFramework.cs
@@ -1,0 +1,29 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+namespace MongoDB.Driver
+{
+    internal static class TargetFramework
+    {
+        public static string Moniker =>
+#if NET452
+            "net452";
+#elif NETSTANDARD1_5
+            "netstandard15";
+#elif NETSTANDARD2_0
+            "netstandard20";
+#endif
+    }
+}

--- a/tests/MongoDB.Bson.TestHelpers/MongoDB.Bson.TestHelpers.csproj
+++ b/tests/MongoDB.Bson.TestHelpers/MongoDB.Bson.TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
+++ b/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
+++ b/tests/MongoDB.Bson.Tests/ObjectModel/Decimal128Tests.cs
@@ -16,7 +16,9 @@
 using System;
 using FluentAssertions;
 using System.Globalization;
+#if !NETCOREAPP1_1
 using System.Threading;
+#endif
 using Xunit;
 
 namespace MongoDB.Bson.Tests
@@ -122,6 +124,7 @@ namespace MongoDB.Bson.Tests
             exception.Should().BeOfType<OverflowException>();
         }
 
+#if !NETCOREAPP1_1
         [Theory]
         [InlineData("123.456", 123.456)]
         public void ToDouble_should_not_depend_on_current_culture(string valueString, double expectedDouble)
@@ -161,6 +164,7 @@ namespace MongoDB.Bson.Tests
                 Thread.CurrentThread.CurrentCulture = currentCulture;
             }
         }
+#endif
 
         [Theory]
         [InlineData((byte)0, "0")]

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonClassMapSerializerISupportInitializeTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonClassMapSerializerISupportInitializeTests.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+#if !NETCOREAPP1_1
 using FluentAssertions;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
@@ -157,3 +158,4 @@ namespace MongoDB.Bson.Tests.Serialization
         }
     }
 }
+#endif

--- a/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerTests.cs
+++ b/tests/MongoDB.Bson.Tests/Serialization/BsonSerializerTests.cs
@@ -14,11 +14,11 @@
 */
 
 using System;
+#if !NETCOREAPP1_1
 using System.ComponentModel;
+#endif
 using System.Globalization;
 using System.Linq;
-using MongoDB.Bson;
-using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.Serializers;
@@ -136,7 +136,8 @@ namespace MongoDB.Bson.Tests.Serialization
             Assert.True(bson.SequenceEqual(rehydrated.ToBson()));
         }
 
-        public class InventoryItem
+#if !NETCOREAPP1_1
+        public class InventoryItem 
             : ISupportInitialize
         {
             public int Price { get; set; }
@@ -169,6 +170,7 @@ namespace MongoDB.Bson.Tests.Serialization
             Assert.True(rehydrated.WasBeginInitCalled);
             Assert.True(rehydrated.WasEndInitCalled);
         }
+#endif
 
         [BsonKnownTypes(typeof(B), typeof(C))]
         private class A

--- a/tests/MongoDB.Bson.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Bson.Tests/TargetFrameworkTests.cs
@@ -1,0 +1,43 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using FluentAssertions;
+using Xunit;
+
+namespace MongoDB.Bson.Tests
+{
+    public class TargetFrameworkTests
+    {
+        [Fact]
+        public void TargetFramework_should_be_valid()
+        {
+            var actual = MongoDB.Bson.TargetFramework.Moniker;
+            var expected = GetExpectedTargetFramework();
+            actual.Should().Be(expected);
+        }
+
+        // private methods
+        private string GetExpectedTargetFramework()
+        {
+#if NETCOREAPP1_1
+            return "netstandard15";
+#elif NETCOREAPP2_1
+            return "netstandard20";
+#elif NET452
+            return "net452";
+#endif
+        }
+    }
+}

--- a/tests/MongoDB.Bson.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Bson.Tests/TargetFrameworkTests.cs
@@ -23,9 +23,9 @@ namespace MongoDB.Bson.Tests
         [Fact]
         public void TargetFramework_should_be_valid()
         {
-            var actual = MongoDB.Bson.TargetFramework.Moniker;
-            var expected = GetExpectedTargetFramework();
-            actual.Should().Be(expected);
+            var actualFramework = MongoDB.Bson.TargetFramework.Moniker;
+            var expectedFramework = GetExpectedTargetFramework();
+            actualFramework.Should().Be(expectedFramework);
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Core.TestHelpers/MongoDB.Driver.Core.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.Core.TestHelpers/MongoDB.Driver.Core.TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/TcpStreamFactoryTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/TcpStreamFactoryTests.cs
@@ -226,9 +226,11 @@ namespace MongoDB.Driver.Core.Connections
             {
             }
 
+#if !NETCOREAPP1_1
             public TestSocket(SocketInformation socketInformation) : base(socketInformation)
             {
             }
+#endif
 
             protected override void Dispose(bool disposing)
             {

--- a/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Core.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/TargetFrameworkTests.cs
@@ -23,9 +23,9 @@ namespace MongoDB.Driver.Core.Tests
         [Fact]
         public void TargetFramework_should_be_valid()
         {
-            var actual = MongoDB.Driver.Core.TargetFramework.Moniker;
-            var expected = GetExpectedTargetFramework();
-            actual.Should().Be(expected);
+            var actualFramework = MongoDB.Driver.Core.TargetFramework.Moniker;
+            var expectedFramework = GetExpectedTargetFramework();
+            actualFramework.Should().Be(expectedFramework);
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Core.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/TargetFrameworkTests.cs
@@ -1,0 +1,43 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using FluentAssertions;
+using Xunit;
+
+namespace MongoDB.Driver.Core.Tests
+{
+    public class TargetFrameworkTests
+    {
+        [Fact]
+        public void TargetFramework_should_be_valid()
+        {
+            var actual = MongoDB.Driver.Core.TargetFramework.Moniker;
+            var expected = GetExpectedTargetFramework();
+            actual.Should().Be(expected);
+        }
+
+        // private methods
+        private string GetExpectedTargetFramework()
+        {
+#if NETCOREAPP1_1
+            return "netstandard15";
+#elif NETCOREAPP2_1
+            return "netstandard20";
+#elif NET452
+            return "net452";
+#endif
+        }
+    }
+}

--- a/tests/MongoDB.Driver.GridFS.Tests/MongoDB.Driver.GridFS.Tests.csproj
+++ b/tests/MongoDB.Driver.GridFS.Tests/MongoDB.Driver.GridFS.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.GridFS.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/TargetFrameworkTests.cs
@@ -1,0 +1,43 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using FluentAssertions;
+using Xunit;
+
+namespace MongoDB.Driver.GridFS.Tests
+{
+    public class TargetFrameworkTests
+    {
+        [Fact]
+        public void TargetFramework_should_be_valid()
+        {
+            var actual = MongoDB.Driver.GridFS.TargetFramework.Moniker;
+            var expected = GetExpectedTargetFramework();
+            actual.Should().Be(expected);
+        }
+
+        // private methods
+        private string GetExpectedTargetFramework()
+        {
+#if NETCOREAPP1_1
+            return "netstandard15";
+#elif NETCOREAPP2_1
+            return "netstandard20";
+#elif NET452
+            return "net452";
+#endif
+        }
+    }
+}

--- a/tests/MongoDB.Driver.GridFS.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.GridFS.Tests/TargetFrameworkTests.cs
@@ -23,9 +23,9 @@ namespace MongoDB.Driver.GridFS.Tests
         [Fact]
         public void TargetFramework_should_be_valid()
         {
-            var actual = MongoDB.Driver.GridFS.TargetFramework.Moniker;
-            var expected = GetExpectedTargetFramework();
-            actual.Should().Be(expected);
+            var actualFramework = MongoDB.Driver.GridFS.TargetFramework.Moniker;
+            var expectedFramework = GetExpectedTargetFramework();
+            actualFramework.Should().Be(expectedFramework);
         }
 
         // private methods

--- a/tests/MongoDB.Driver.Legacy.TestHelpers/MongoDB.Driver.Legacy.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.Legacy.TestHelpers/MongoDB.Driver.Legacy.TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoDB.Driver.Legacy.Tests.csproj
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoDB.Driver.Legacy.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Legacy.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/TargetFrameworkTests.cs
@@ -1,0 +1,43 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using FluentAssertions;
+using Xunit;
+
+namespace MongoDB.Driver.Tests
+{
+    public class TargetFrameworkTests
+    {
+        [Fact]
+        public void TargetFramework_should_be_valid()
+        {
+            var actual = MongoDB.Driver.Legacy.TargetFramework.Moniker;
+            var expected = GetExpectedTargetFramework();
+            actual.Should().Be(expected);
+        }
+
+        // private methods
+        private string GetExpectedTargetFramework()
+        {
+#if NETCOREAPP1_1
+            return "netstandard15";
+#elif NETCOREAPP2_1
+            return "netstandard20";
+#elif NET452
+            return "net452";
+#endif
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Legacy.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/TargetFrameworkTests.cs
@@ -23,9 +23,9 @@ namespace MongoDB.Driver.Tests
         [Fact]
         public void TargetFramework_should_be_valid()
         {
-            var actual = MongoDB.Driver.Legacy.TargetFramework.Moniker;
-            var expected = GetExpectedTargetFramework();
-            actual.Should().Be(expected);
+            var actualFramework = MongoDB.Driver.Legacy.TargetFramework.Moniker;
+            var expectedFramework = GetExpectedTargetFramework();
+            actualFramework.Should().Be(expectedFramework);
         }
 
         // private methods

--- a/tests/MongoDB.Driver.TestHelpers/MongoDB.Driver.TestHelpers.csproj
+++ b/tests/MongoDB.Driver.TestHelpers/MongoDB.Driver.TestHelpers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
+++ b/tests/MongoDB.Driver.Tests/MongoDB.Driver.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;net452</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/tests/MongoDB.Driver.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.Tests/TargetFrameworkTests.cs
@@ -1,0 +1,43 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using FluentAssertions;
+using Xunit;
+
+namespace MongoDB.Driver.Tests
+{
+    public class TargetFrameworkTests
+    {
+        [Fact]
+        public void TargetFramework_should_be_valid()
+        {
+            var actual = MongoDB.Driver.TargetFramework.Moniker;
+            var expected = GetExpectedTargetFramework();
+            actual.Should().Be(expected);
+        }
+
+        // private methods
+        private string GetExpectedTargetFramework()
+        {
+#if NETCOREAPP1_1
+            return "netstandard15";
+#elif NETCOREAPP2_1
+            return "netstandard20";
+#elif NET452
+            return "net452";
+#endif
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Tests/TargetFrameworkTests.cs
+++ b/tests/MongoDB.Driver.Tests/TargetFrameworkTests.cs
@@ -23,9 +23,9 @@ namespace MongoDB.Driver.Tests
         [Fact]
         public void TargetFramework_should_be_valid()
         {
-            var actual = MongoDB.Driver.TargetFramework.Moniker;
-            var expected = GetExpectedTargetFramework();
-            actual.Should().Be(expected);
+            var actualFramework = MongoDB.Driver.TargetFramework.Moniker;
+            var expectedFramework = GetExpectedTargetFramework();
+            actualFramework.Should().Be(expectedFramework);
         }
 
         // private methods


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e29a9df3e8e8649e802a08b

**NOTE:** It can be required to run: `dotnet restore`.
