### PR TITLE
CSHARP-2486: Fix packaging issues.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Compression/Snappy/Snappy64NativeMethods.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/Snappy/Snappy64NativeMethods.cs
@@ -90,7 +90,7 @@ namespace MongoDB.Driver.Core.Compression.Snappy
                 switch (currentPlatform)
                 {
                     case SupportedPlatform.Windows:
-                        return @"..\..\x64\native\windows\snappy64.dll";
+                        return @"runtimes\win-x64\native\snappy64.dll";
                     case SupportedPlatform.Linux: // TODO: add support for Linux and MacOS later
                     case SupportedPlatform.MacOS:
                     default:

--- a/src/MongoDB.Driver.Core/Core/Compression/Snappy/Snappy64NativeMethods.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/Snappy/Snappy64NativeMethods.cs
@@ -90,7 +90,7 @@ namespace MongoDB.Driver.Core.Compression.Snappy
                 switch (currentPlatform)
                 {
                     case SupportedPlatform.Windows:
-                        return @"runtimes\win-x64\native\snappy64.dll";
+                        return @"runtimes\win\native\snappy64.dll";
                     case SupportedPlatform.Linux: // TODO: add support for Linux and MacOS later
                     case SupportedPlatform.MacOS:
                     default:

--- a/src/MongoDB.Driver.Core/Core/Compression/Zstd/Zstandard64NativeMethods.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/Zstd/Zstandard64NativeMethods.cs
@@ -258,7 +258,7 @@ namespace MongoDB.Driver.Core.Compression.Zstd
                 switch (currentPlatform)
                 {
                     case SupportedPlatform.Windows:
-                        return @"..\..\x64\native\windows\libzstd.dll";
+                        return @"runtimes\win-x64\native\libzstd.dll";
                     case SupportedPlatform.Linux: // TODO: add support for Linux and MacOS later
                     case SupportedPlatform.MacOS:
                     default:

--- a/src/MongoDB.Driver.Core/Core/Compression/Zstd/Zstandard64NativeMethods.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/Zstd/Zstandard64NativeMethods.cs
@@ -258,7 +258,7 @@ namespace MongoDB.Driver.Core.Compression.Zstd
                 switch (currentPlatform)
                 {
                     case SupportedPlatform.Windows:
-                        return @"runtimes\win-x64\native\libzstd.dll";
+                        return @"runtimes\win\native\libzstd.dll";
                     case SupportedPlatform.Linux: // TODO: add support for Linux and MacOS later
                     case SupportedPlatform.MacOS:
                     default:

--- a/src/MongoDB.Driver.Core/Core/NativeLibraryLoader/RelativeLibraryLocatorBase.cs
+++ b/src/MongoDB.Driver.Core/Core/NativeLibraryLoader/RelativeLibraryLocatorBase.cs
@@ -53,6 +53,7 @@ namespace MongoDB.Driver.Core.NativeLibraryLoader
             var absolutePathsToCheck = new[]
             {
                 Path.Combine(libraryBasePath, libraryName),  // look in the current assembly folder
+                Path.Combine(libraryBasePath, @"..\..\", relativePath),
                 Path.Combine(libraryBasePath, relativePath)
             };
 

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -50,6 +50,12 @@
     <None Remove="snappy64.dll" />
   </ItemGroup>
 
+  <!--Compression-->
+  <PropertyGroup>
+    <CompressionRuntimesPath>runtimes/win-x64/native</CompressionRuntimesPath>
+  </PropertyGroup>
+
+  <!--Snappy-->
   <PropertyGroup>
     <SnappyBinaries>Core/Compression/Snappy/lib/win</SnappyBinaries>
   </PropertyGroup>
@@ -57,7 +63,8 @@
   <ItemGroup>
     <Content Include="$(SnappyBinaries)/snappy64.dll">
       <Pack>true</Pack>
-      <PackagePath>x64/native/windows</PackagePath>
+      <PackagePath>$(CompressionRuntimesPath)</PackagePath>
+      <Visible>false</Visible>
     </Content>
   </ItemGroup>
 
@@ -68,6 +75,7 @@
     </Content>
   </ItemGroup>
 
+  <!--Zstd-->
   <PropertyGroup>
     <ZstdBinaries>Core/Compression/Zstd/lib/win</ZstdBinaries>
   </PropertyGroup>
@@ -75,7 +83,7 @@
   <ItemGroup>
     <Content Include="$(ZstdBinaries)/libzstd.dll">
       <Pack>true</Pack>
-      <PackagePath>x64/native/windows</PackagePath>
+      <PackagePath>$(CompressionRuntimesPath)</PackagePath>
     </Content>
   </ItemGroup>
 
@@ -128,5 +136,4 @@
     <None Include="..\..\License.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
     <None Include="..\..\THIRD-PARTY-NOTICES" Pack="true" PackagePath="\" />
   </ItemGroup>
-
 </Project>

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -46,16 +46,16 @@
     <NoWarn>NU5100</NoWarn>
   </PropertyGroup>
 
+  <!--Compression-->
+  <PropertyGroup>
+    <CompressionRuntimesPath>runtimes/win/native</CompressionRuntimesPath>
+  </PropertyGroup>
+
+  <!--Snappy-->
   <ItemGroup>
     <None Remove="snappy64.dll" />
   </ItemGroup>
 
-  <!--Compression-->
-  <PropertyGroup>
-    <CompressionRuntimesPath>runtimes/win-x64/native</CompressionRuntimesPath>
-  </PropertyGroup>
-
-  <!--Snappy-->
   <PropertyGroup>
     <SnappyBinaries>Core/Compression/Snappy/lib/win</SnappyBinaries>
   </PropertyGroup>
@@ -64,7 +64,6 @@
     <Content Include="$(SnappyBinaries)/snappy64.dll">
       <Pack>true</Pack>
       <PackagePath>$(CompressionRuntimesPath)</PackagePath>
-      <Visible>false</Visible>
     </Content>
   </ItemGroup>
 
@@ -76,6 +75,10 @@
   </ItemGroup>
 
   <!--Zstd-->
+  <ItemGroup>
+    <None Remove="libzstd.dll" />
+  </ItemGroup>
+
   <PropertyGroup>
     <ZstdBinaries>Core/Compression/Zstd/lib/win</ZstdBinaries>
   </PropertyGroup>

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.targets
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.targets
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+    <PropertyGroup>
+      <CompressionRuntimesPath>runtimes/win-x64/native</CompressionRuntimesPath>
+    </PropertyGroup>
+
     <ItemGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-        <Content Include="$(MSBuildThisFileDirectory)../x64/native/windows/snappy64.dll">
+        <Content Include="$(MSBuildThisFileDirectory)../$(CompressionRuntimesPath)/snappy64.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>snappy64.dll</Link>
         </Content>
     </ItemGroup>
 
     <ItemGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-        <Content Include="$(MSBuildThisFileDirectory)../x64/native/windows/libzstd.dll">
+        <Content Include="$(MSBuildThisFileDirectory)../$(CompressionRuntimesPath)/libzstd.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Link>libzstd.dll</Link>
         </Content>

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.targets
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.targets
@@ -2,9 +2,10 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-      <CompressionRuntimesPath>runtimes/win-x64/native</CompressionRuntimesPath>
+      <CompressionRuntimesPath>runtimes/win/native</CompressionRuntimesPath>
     </PropertyGroup>
 
+    <!--snappy-->
     <ItemGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
         <Content Include="$(MSBuildThisFileDirectory)../$(CompressionRuntimesPath)/snappy64.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -12,6 +13,7 @@
         </Content>
     </ItemGroup>
 
+    <!--zstd-->
     <ItemGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
         <Content Include="$(MSBuildThisFileDirectory)../$(CompressionRuntimesPath)/libzstd.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
This PR contains part of the work from https://github.com/DmitryLukyanov/mongo-csharp-driver/pull/94
After it will be ready, we will need to make the same changes for snappy and FLE.

EG: https://evergreen.mongodb.com/version/5e39bc672fbabe1e325935a9

I took this nuget as example: https://github.com/libgit2/libgit2sharp.nativebinaries
Helpful llinks:
https://dev.to/jeikabu/nupkg-containing-native-libraries-1576
https://docs.microsoft.com/en-us/dotnet/core/rid-catalog
https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks