### PR TITLE
CSHARP-2928: Use Ordinal string comparison in ScramShaAuthenticator.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Authentication/ScramShaAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/ScramShaAuthenticator.cs
@@ -14,12 +14,12 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using MongoDB.Bson.IO;
+#if NET452
 using MongoDB.Driver.Core.Authentication.Vendored;
+#endif
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Misc;
 
@@ -168,7 +168,6 @@ namespace MongoDB.Driver.Core.Authentication
         
         private class ClientFirst : ISaslStep
         {
-
             private readonly byte[] _bytesToSendToServer;
             private readonly string _clientFirstMessageBare;
             private readonly UsernamePasswordCredential _credential;
@@ -211,7 +210,7 @@ namespace MongoDB.Driver.Core.Authentication
                 var map = SaslMapParser.Parse(serverFirstMessage);
 
                 var r = map['r'];
-                if (!r.StartsWith(_rPrefix))
+                if (!r.StartsWith(_rPrefix, StringComparison.Ordinal))
                 {
                     throw new MongoAuthenticationException(conversation.ConnectionId, message: "Server sent an invalid nonce.");
                 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha256AuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha256AuthenticatorTests.cs
@@ -32,8 +32,14 @@ namespace MongoDB.Driver.Core.Authentication
 {
     public class ScramSha256AuthenticatorTests
     {
-        private static readonly UsernamePasswordCredential __credential
-            = new UsernamePasswordCredential("source", "user", "pencil");
+        // private constants
+        private const string _clientNonce = "rOprNGfwEbeRWgbNEkqO";
+        private const int _iterationCount = 4096;
+        private const string _serverNonce = "%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0";
+        private const string _serverSalt = "W22ZaJ0SNY7soEsUEjb6gQ==";
+
+        // private static
+        private static readonly UsernamePasswordCredential __credential = new UsernamePasswordCredential("source", "user", "pencil");
         private static readonly ClusterId __clusterId = new ClusterId();
         private static readonly ServerId __serverId = new ServerId(__clusterId, new DnsEndPoint("localhost", 27017));
         private static readonly ConnectionDescription __description = new ConnectionDescription(
@@ -49,11 +55,6 @@ namespace MongoDB.Driver.Core.Authentication
          * C: c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ=
          * S: v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4=
         */
-
-        private const string _clientNonce = "rOprNGfwEbeRWgbNEkqO";
-        private const int _iterationCount = 4096;
-        private const string _serverNonce = "%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0";
-        private const string _serverSalt = "W22ZaJ0SNY7soEsUEjb6gQ==";
 
         private static readonly string _clientRequest1 = $"n,,n=user,r={_clientNonce}";
         private static readonly string _serverResponse1 =
@@ -316,7 +317,7 @@ namespace MongoDB.Driver.Core.Authentication
             [Values("da-DK", "en-US")] string name,
             [Values(false, true)] bool async)
         {
-            SetCultureAndRefreshAfterTest(name, () =>
+            SetCultureAndResetAfterTest(name, () =>
             {
                 var randomStringGenerator = new ConstantRandomStringGenerator("a");
 
@@ -340,7 +341,7 @@ namespace MongoDB.Driver.Core.Authentication
                 Authenticate(subject, mockConnection, async);
             });
 
-            void SetCultureAndRefreshAfterTest(string cultureName, Action test)
+            void SetCultureAndResetAfterTest(string cultureName, Action test)
             {
                 var originalCulture = Thread.CurrentThread.CurrentCulture;
                 Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(cultureName);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha256AuthenticatorTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Authentication/ScramSha256AuthenticatorTests.cs
@@ -27,6 +27,7 @@ using MongoDB.Driver.Core.WireProtocol.Messages;
 using Xunit;
 using MongoDB.Driver.Core.Connections;
 using MongoDB.Bson.TestHelpers.XunitExtensions;
+
 namespace MongoDB.Driver.Core.Authentication
 {
     public class ScramSha256AuthenticatorTests
@@ -39,7 +40,7 @@ namespace MongoDB.Driver.Core.Authentication
             new ConnectionId(__serverId),
             new IsMasterResult(new BsonDocument("ok", 1).Add("ismaster", 1)),
             new BuildInfoResult(new BsonDocument("version", "4.0.0")));
-        
+
         /*
          * This is a simple example of a SCRAM-SHA-256 authentication exchange. The username
          * 'user' and password 'pencil' are being used, with a client nonce of "rOprNGfwEbeRWgbNEkqO" 
@@ -60,31 +61,36 @@ namespace MongoDB.Driver.Core.Authentication
         private static readonly string _clientRequest2 =
             $"c=biws,r={_clientNonce}{_serverNonce},p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ=";
         private static readonly string _serverReponse2 = "v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4=";
-        
+
         private static void Authenticate(
             ScramSha256Authenticator authenticator,
             IConnection connection,
-            ConnectionDescription description,
             bool async)
         {
             if (async)
             {
-                authenticator.AuthenticateAsync(connection, __description, CancellationToken.None).GetAwaiter().GetResult();
+                authenticator
+                    .AuthenticateAsync(connection, __description, CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
             }
-            authenticator.Authenticate(connection, __description, CancellationToken.None);
+            else
+            {
+                authenticator.Authenticate(connection, __description, CancellationToken.None);
+            }
         }
-        
+
         /* In response, the server sends a "server-first-message" containing the
         * user's iteration count i and the user's salt, and appends its own
         * nonce to the client-specified one. */
         private static string CreateSaslStartReply(
-            string clientSaslStart, 
-            string serverNonce, 
-            string serverSalt, 
+            string clientSaslStart,
+            string serverNonce,
+            string serverSalt,
             int iterationCount)
         {
             // strip expected GS2 header of "n,," before parsing map
-            var clientNonce = SaslMapParser.Parse(clientSaslStart.Substring(3))['r']; 
+            var clientNonce = SaslMapParser.Parse(clientSaslStart.Substring(3))['r'];
             return $"r={clientNonce}{serverNonce},s={serverSalt},i={iterationCount}";
         }
 
@@ -93,15 +99,15 @@ namespace MongoDB.Driver.Core.Authentication
         {
             return message.Substring(0, message.Length - poison.Length) + poison;
         }
-        
+
         private static string ToUtf8Base64(string s)
         {
             return Convert.ToBase64String((System.Text.Encoding.UTF8.GetBytes(s)));
         }
-         
+
         [Fact]
         public void Constructor_should_throw_an_ArgumentNullException_when_credential_is_null()
-        {               
+        {
             var exception = Record.Exception(() => new ScramSha256Authenticator(null));
             exception.Should().BeOfType<ArgumentNullException>();
         }
@@ -117,12 +123,12 @@ namespace MongoDB.Driver.Core.Authentication
             var connection = new MockConnection(__serverId);
             connection.EnqueueReplyMessage(reply);
 
-            var act = async  
+            var act = async
                 ? () => subject.AuthenticateAsync(connection, __description, CancellationToken.None).GetAwaiter().GetResult()
-                : (Action) (() => subject.Authenticate(connection, __description, CancellationToken.None));
+                : (Action)(() => subject.Authenticate(connection, __description, CancellationToken.None));
 
             var exception = Record.Exception(act);
-            
+
             exception.Should().BeOfType<MongoAuthenticationException>();
         }
 
@@ -136,7 +142,7 @@ namespace MongoDB.Driver.Core.Authentication
             var poisonedSaslStart = PoisonSaslMessage(message: _clientRequest1, poison: "bluePill");
             var poisonedSaslStartReply = CreateSaslStartReply(poisonedSaslStart, _serverNonce, _serverSalt, _iterationCount);
             var poisonedSaslStartReplyMessage = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson(
-                @"{conversationId: 1, " + 
+                @"{conversationId: 1, " +
                 $" payload: BinData(0,\"{ToUtf8Base64(poisonedSaslStartReply)}\")," +
                 @" done: false,
                    ok: 1}"));
@@ -144,12 +150,12 @@ namespace MongoDB.Driver.Core.Authentication
             var connection = new MockConnection(__serverId);
             connection.EnqueueReplyMessage(poisonedSaslStartReplyMessage);
 
-            var act = async  
+            var act = async
                 ? () => subject.AuthenticateAsync(connection, __description, CancellationToken.None).GetAwaiter().GetResult()
-                : (Action) (() => subject.Authenticate(connection, __description, CancellationToken.None));
+                : (Action)(() => subject.Authenticate(connection, __description, CancellationToken.None));
 
             var exception = Record.Exception(act);
-            
+
             exception.Should().BeOfType<MongoAuthenticationException>();
         }
 
@@ -160,17 +166,17 @@ namespace MongoDB.Driver.Core.Authentication
         {
             var randomStringGenerator = new ConstantRandomStringGenerator(_clientNonce);
             var subject = new ScramSha256Authenticator(__credential, randomStringGenerator);
-            
+
             var saslStartReply = CreateSaslStartReply(_clientRequest1, _serverNonce, _serverSalt, _iterationCount);
-            var poisonedSaslContinueReply = PoisonSaslMessage(message: _serverReponse2, poison: "redApple"); 
+            var poisonedSaslContinueReply = PoisonSaslMessage(message: _serverReponse2, poison: "redApple");
             var saslStartReplyMessage = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson(
-                @"{conversationId: 1, " + 
+                @"{conversationId: 1, " +
                 $" payload: BinData(0,\"{ToUtf8Base64(saslStartReply)}\")," +
                 @" done: false, 
                    ok: 1}"));
             var poisonedSaslContinueReplyMessage = MessageHelper.BuildReply(RawBsonDocumentHelper.FromJson(
-                @"{conversationId: 1, "+
-                $" payload: BinData(0,\"{ToUtf8Base64(poisonedSaslContinueReply)}\")," + 
+                @"{conversationId: 1, " +
+                $" payload: BinData(0,\"{ToUtf8Base64(poisonedSaslContinueReply)}\")," +
                 @" done: true, 
                    ok: 1}"));
 
@@ -187,7 +193,7 @@ namespace MongoDB.Driver.Core.Authentication
             {
                 act = () => subject.Authenticate(connection, __description, CancellationToken.None);
             }
-            
+
             var exception = Record.Exception(act);
 
             exception.Should().BeOfType<MongoAuthenticationException>();
@@ -202,13 +208,13 @@ namespace MongoDB.Driver.Core.Authentication
             var subject = new ScramSha256Authenticator(__credential, randomStringGenerator);
 
             var saslStartReply = MessageHelper.BuildReply<RawBsonDocument>(RawBsonDocumentHelper.FromJson(
-                @"{conversationId: 1," + 
+                @"{conversationId: 1," +
                 $" payload: BinData(0,\"{ToUtf8Base64(_serverResponse1)}\")," +
                 @" done: false, 
                    ok: 1}"));
             var saslContinueReply = MessageHelper.BuildReply<RawBsonDocument>(RawBsonDocumentHelper.FromJson(
                 @"{conversationId: 1," +
-                $" payload: BinData(0,\"{ToUtf8Base64(_serverReponse2)}\")," + 
+                $" payload: BinData(0,\"{ToUtf8Base64(_serverReponse2)}\")," +
                 @" done: true, 
                    ok: 1}"));
 
@@ -241,24 +247,24 @@ namespace MongoDB.Driver.Core.Authentication
             actualRequestId1.Should().BeInRange(actualRequestId0 + 1, actualRequestId0 + 11);
 
             sentMessages[0].Should().Be(
-                @"{opcode: ""query""," + 
+                @"{opcode: ""query""," +
                 $" requestId: {actualRequestId0}," +
                 @" database: ""source"", 
                    collection: ""$cmd"", 
                    batchSize: -1, 
                    slaveOk: true, 
                    query: {saslStart: 1, 
-                           mechanism: ""SCRAM-SHA-256""," + 
+                           mechanism: ""SCRAM-SHA-256""," +
                 $"         payload: new BinData(0, \"{ToUtf8Base64(_clientRequest1)}\")}}}}");
             sentMessages[1].Should().Be(
-                @"{opcode: ""query""," + 
+                @"{opcode: ""query""," +
                 $" requestId: {actualRequestId1}," +
                 @" database: ""source"", 
                    collection: ""$cmd"", 
                    batchSize: -1, 
                    slaveOk: true, 
                    query: {saslContinue: 1, 
-                           conversationId: 1, " + 
+                           conversationId: 1, " +
                 $"         payload: new BinData(0, \"{ToUtf8Base64(_clientRequest2)}\")}}}}");
         }
 
@@ -302,6 +308,54 @@ namespace MongoDB.Driver.Core.Authentication
             subject._cache()._cacheKey().Should().NotBe(null);
             subject._cache()._cachedEntry().Should().NotBe(null);
         }
+
+#if !NETCOREAPP1_1
+        [Theory]
+        [ParameterAttributeData]
+        public void Authenticate_should_work_regardless_of_culture(
+            [Values("da-DK", "en-US")] string name,
+            [Values(false, true)] bool async)
+        {
+            SetCultureAndRefreshAfterTest(name, () =>
+            {
+                var randomStringGenerator = new ConstantRandomStringGenerator("a");
+
+                // ScramSha1Authenticator will have exactly the same code paths
+                var subject = new ScramSha256Authenticator(__credential, randomStringGenerator);
+                var mockConnection = new MockConnection();
+
+                var payload1 = $"r=aa,s={_serverSalt},i=1";
+                var serverResponse1 = $"{{ ok : 1, payload : BinData(0,\"{ToUtf8Base64(payload1)}\"), done : true, conversationId : 1 }}";
+                var serverResponseRawDocument1 = RawBsonDocumentHelper.FromJson(serverResponse1);
+                var serverResponseMessage1 = MessageHelper.BuildReply(serverResponseRawDocument1);
+
+                var payload2 = $"v=v1wZS02d7kZVSzuKoB7TuI+jIpSsKvnQUkU9Oqj2t+w=";
+                var serverResponse2 = $"{{ ok : 1, payload : BinData(0,\"{ToUtf8Base64(payload2)}\"), done : true }}";
+                var serverResponseRawDocument2 = RawBsonDocumentHelper.FromJson(serverResponse2);
+                var serverResponseMessage2 = MessageHelper.BuildReply(serverResponseRawDocument2);
+
+                mockConnection.EnqueueReplyMessage(serverResponseMessage1);
+                mockConnection.EnqueueReplyMessage(serverResponseMessage2);
+
+                Authenticate(subject, mockConnection, async);
+            });
+
+            void SetCultureAndRefreshAfterTest(string cultureName, Action test)
+            {
+                var originalCulture = Thread.CurrentThread.CurrentCulture;
+                Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(cultureName);
+
+                try
+                {
+                    test();
+                }
+                finally
+                {
+                    Thread.CurrentThread.CurrentCulture = originalCulture;
+                }
+            }
+        }
+#endif
     }
 
     internal static class ScramShaAuthenticatorReflector
@@ -313,10 +367,10 @@ namespace MongoDB.Driver.Core.Authentication
 
     internal static class ScramCacheReflector
     {
-        public static ScramCacheKey _cacheKey (this ScramCache obj) =>
+        public static ScramCacheKey _cacheKey(this ScramCache obj) =>
             (ScramCacheKey)Reflector.GetFieldValue(obj, nameof(_cacheKey));
 
-        public static ScramCacheEntry _cachedEntry (this ScramCache obj) =>
+        public static ScramCacheEntry _cachedEntry(this ScramCache obj) =>
             (ScramCacheEntry)Reflector.GetFieldValue(obj, nameof(_cachedEntry));
     }
 }


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e3b4f229ccd4e620bd13b5c