### PR TITLE
CSHARP-2872: Expand use of error labels for RetryableWrites.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -76,7 +76,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __scramSha1Authentication = new Feature("ScramSha1Authentication", new SemanticVersion(3, 0, 0));
         private static readonly Feature __scramSha256Authentication = new Feature("ScramSha256Authentication", new SemanticVersion(4, 0, 0, ""));
         private static readonly Feature __serverExtractsUsernameFromX509Certificate = new Feature("ServerExtractsUsernameFromX509Certificate", new SemanticVersion(3, 3, 12));
-        private static readonly Feature __serverReturnsRetryableWriteErrorLabelFeature = new Feature("ServerReturnsRetryableWriteErrorLabelFeature", new SemanticVersion(4, 3, 0));
+        private static readonly Feature __serverReturnsRetryableWriteErrorLabel = new Feature("ServerReturnsRetryableWriteErrorLabel", new SemanticVersion(4, 3, 0));
         private static readonly Feature __shardedTransactions = new Feature("ShardedTransactions", new SemanticVersion(4, 1, 6));
         private static readonly Feature __tailableCursor = new Feature("TailableCursor", new SemanticVersion(3, 2, 0));
         private static readonly Feature __transactions = new Feature("Transactions", new SemanticVersion(4, 0, 0));
@@ -353,7 +353,7 @@ namespace MongoDB.Driver.Core.Misc
         /// <summary>
         /// Gets the server returns retryable writeError label feature.
         /// </summary>
-        public static Feature ServerReturnsRetryableWriteErrorLabelFeature => __serverReturnsRetryableWriteErrorLabelFeature;
+        public static Feature ServerReturnsRetryableWriteErrorLabel => __serverReturnsRetryableWriteErrorLabel;
 
         /// <summary>
         /// Gets the sharded transactions feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -72,9 +72,11 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __partialIndexes = new Feature("PartialIndexes", new SemanticVersion(3, 2, 0));
         private static readonly ReadConcernFeature __readConcern = new ReadConcernFeature("ReadConcern", new SemanticVersion(3, 2, 0));
         private static readonly Feature __retryableReads = new Feature("RetryableReads", new SemanticVersion(3, 6, 0));
+        private static readonly Feature __retryableWrites = new Feature("RetryableWrites", new SemanticVersion(3, 6, 0));
         private static readonly Feature __scramSha1Authentication = new Feature("ScramSha1Authentication", new SemanticVersion(3, 0, 0));
         private static readonly Feature __scramSha256Authentication = new Feature("ScramSha256Authentication", new SemanticVersion(4, 0, 0, ""));
         private static readonly Feature __serverExtractsUsernameFromX509Certificate = new Feature("ServerExtractsUsernameFromX509Certificate", new SemanticVersion(3, 3, 12));
+        private static readonly Feature __serverReturnsRetryableWriteErrorLabelFeature = new Feature("ServerReturnsRetryableWriteErrorLabelFeature", new SemanticVersion(4, 3, 0, ""));
         private static readonly Feature __shardedTransactions = new Feature("ShardedTransactions", new SemanticVersion(4, 1, 6));
         private static readonly Feature __tailableCursor = new Feature("TailableCursor", new SemanticVersion(3, 2, 0));
         private static readonly Feature __transactions = new Feature("Transactions", new SemanticVersion(4, 0, 0));
@@ -329,6 +331,11 @@ namespace MongoDB.Driver.Core.Misc
         public static Feature RetryableReads => __retryableReads;
 
         /// <summary>
+        /// Gets the retryable writes feature.
+        /// </summary>
+        public static Feature RetryableWrites => __retryableWrites;
+
+        /// <summary>
         /// Gets the scram sha1 authentication feature.
         /// </summary>
         public static Feature ScramSha1Authentication => __scramSha1Authentication;
@@ -342,6 +349,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the server extracts username from X509 certificate feature.
         /// </summary>
         public static Feature ServerExtractsUsernameFromX509Certificate => __serverExtractsUsernameFromX509Certificate;
+
+        /// <summary>
+        /// Gets the server returns retryable writeError label feature.
+        /// </summary>
+        public static Feature ServerReturnsRetryableWriteErrorLabelFeature => __serverReturnsRetryableWriteErrorLabelFeature;
 
         /// <summary>
         /// Gets the sharded transactions feature.

--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -76,7 +76,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __scramSha1Authentication = new Feature("ScramSha1Authentication", new SemanticVersion(3, 0, 0));
         private static readonly Feature __scramSha256Authentication = new Feature("ScramSha256Authentication", new SemanticVersion(4, 0, 0, ""));
         private static readonly Feature __serverExtractsUsernameFromX509Certificate = new Feature("ServerExtractsUsernameFromX509Certificate", new SemanticVersion(3, 3, 12));
-        private static readonly Feature __serverReturnsRetryableWriteErrorLabelFeature = new Feature("ServerReturnsRetryableWriteErrorLabelFeature", new SemanticVersion(4, 3, 0, ""));
+        private static readonly Feature __serverReturnsRetryableWriteErrorLabelFeature = new Feature("ServerReturnsRetryableWriteErrorLabelFeature", new SemanticVersion(4, 3, 0));
         private static readonly Feature __shardedTransactions = new Feature("ShardedTransactions", new SemanticVersion(4, 1, 6));
         private static readonly Feature __tailableCursor = new Feature("TailableCursor", new SemanticVersion(3, 2, 0));
         private static readonly Feature __transactions = new Feature("Transactions", new SemanticVersion(4, 0, 0));

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryabilityHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryabilityHelper.cs
@@ -84,7 +84,7 @@ namespace MongoDB.Driver.Core.Operations
         // public static methods
         public static void AddRetryableWriteErrorLabelIfRequired(Exception exception)
         {
-            if (IsRetryableWriteException(exception) && exception is MongoException mongoException)
+            if (ShouldRetryableWriteExceptionLabelBeAdded(exception) && exception is MongoException mongoException)
             {
                 mongoException.AddErrorLabel(RetryableWriteErrorLabel);
             }
@@ -129,6 +129,12 @@ namespace MongoDB.Driver.Core.Operations
 
         public static bool IsRetryableWriteException(Exception exception)
         {
+            return exception is MongoException mongoException ? mongoException.HasErrorLabel(RetryableWriteErrorLabel) : false;
+        }
+
+        // private static methods
+        private static bool ShouldRetryableWriteExceptionLabelBeAdded(Exception exception)
+        {
             if (__retryableWriteExceptions.Contains(exception.GetType()))
             {
                 return true;
@@ -137,11 +143,6 @@ namespace MongoDB.Driver.Core.Operations
             var commandException = exception as MongoCommandException;
             if (commandException != null)
             {
-                if (commandException.HasErrorLabel(RetryableWriteErrorLabel))
-                {
-                    return true;
-                }
-
                 var code = (ServerErrorCode)commandException.Code;
                 if (__retryableWriteErrorCodes.Contains(code))
                 {

--- a/src/MongoDB.Driver.Core/Core/Operations/RetryabilityHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/RetryabilityHelper.cs
@@ -82,11 +82,11 @@ namespace MongoDB.Driver.Core.Operations
         }
 
         // public static methods
-        public static void AddRetryableWriteErrorLabelIfRequired(Exception exception)
+        public static void AddRetryableWriteErrorLabelIfRequired(MongoException exception)
         {
-            if (ShouldRetryableWriteExceptionLabelBeAdded(exception) && exception is MongoException mongoException)
+            if (ShouldRetryableWriteExceptionLabelBeAdded(exception))
             {
-                mongoException.AddErrorLabel(RetryableWriteErrorLabel);
+                exception.AddErrorLabel(RetryableWriteErrorLabel);
             }
         }
 
@@ -172,16 +172,6 @@ namespace MongoDB.Driver.Core.Operations
                         case ServerErrorCode.SocketException:
                         case ServerErrorCode.ExceededTimeLimit:
                             return true;
-                    }
-
-                    if (writeConcernError.TryGetValue("errmsg", out var bsonMessage))
-                    {
-                        var message = bsonMessage.ToString();
-                        if (message.IndexOf("not master", StringComparison.OrdinalIgnoreCase) != -1 ||
-                            message.IndexOf("node is recovering", StringComparison.OrdinalIgnoreCase) != -1)
-                        {
-                            return true;
-                        }
                     }
                 }
             }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -181,7 +181,7 @@ namespace MongoDB.Driver.Core.WireProtocol
 
                 if ((exception is MongoConnectionException) || // network error
                     (Feature.RetryableWrites.IsSupported(serverVersion) &&
-                    !Feature.ServerReturnsRetryableWriteErrorLabelFeature.IsSupported(serverVersion)))
+                    !Feature.ServerReturnsRetryableWriteErrorLabel.IsSupported(serverVersion)))
                 {
                     RetryabilityHelper.AddRetryableWriteErrorLabelIfRequired(mongoException);
                 }

--- a/src/MongoDB.Driver.Core/MongoCommandException.cs
+++ b/src/MongoDB.Driver.Core/MongoCommandException.cs
@@ -31,7 +31,12 @@ namespace MongoDB.Driver
     public class MongoCommandException : MongoServerException
     {
         #region static
-        private static void AddErrorLabelsFromCommandResult(MongoCommandException exception, BsonDocument result)
+        /// <summary>
+        /// Adds error labels from a command result document into the top-level label list.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        /// <param name="result">The result document.</param>
+        protected static void AddErrorLabelsFromCommandResult(MongoCommandException exception, BsonDocument result)
         {
             // note: make a best effort to extract the error labels from the result, but never throw an exception
             if (result != null)

--- a/src/MongoDB.Driver.Core/ServerErrorCode.cs
+++ b/src/MongoDB.Driver.Core/ServerErrorCode.cs
@@ -22,7 +22,7 @@ namespace MongoDB.Driver
         CappedPositionLost = 136,
         CursorKilled = 237,
         ElectionInProgress = 216,
-        ExceededTimeLimit = 50,
+        ExceededTimeLimit = 262,
         HostNotFound = 7,
         HostUnreachable = 6,
         Interrupted = 11601,
@@ -38,6 +38,7 @@ namespace MongoDB.Driver
         SocketException = 9001,
         UnknownReplWriteConcern = 79,
         UnsatisfiableWriteConcern = 100,
-        WriteConcernFailed = 64
+        WriteConcernFailed = 64,
+        MaxTimeMSExpired = 50
     }
 }

--- a/tests/MongoDB.Driver.Core.TestHelpers/CoreExceptionHelper.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/CoreExceptionHelper.cs
@@ -92,5 +92,22 @@ namespace MongoDB.Driver.Core.TestHelpers
 
             return commandException;
         }
+
+        public static MongoCommandException CreateMongoWriteConcernException(BsonDocument writeConcernResultDocument, string label = null)
+        {
+            var clusterId = new ClusterId(1);
+            var endPoint = new DnsEndPoint("localhost", 27017);
+            var serverId = new ServerId(clusterId, endPoint);
+            var connectionId = new ConnectionId(serverId);
+            var message = "Fake MongoWriteConcernException";
+            var writeConcernResult = new WriteConcernResult(writeConcernResultDocument);
+            var writeConcernException = new MongoWriteConcernException(connectionId, message, writeConcernResult);
+            if (label != null)
+            {
+                writeConcernException.AddErrorLabel(label);
+            }
+
+            return writeConcernException;
+        }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/RetryabilityHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/RetryabilityHelperTests.cs
@@ -171,7 +171,7 @@ namespace MongoDB.Driver.Core.Operations
 
         [Theory]
         [ParameterAttributeData]
-        public void IsRetryableWriteException_should_work_as_expected([Values(false, true)] bool hasRetryableWriteLabel)
+        public void IsRetryableWriteException_should_return_expected_result([Values(false, true)] bool hasRetryableWriteLabel)
         {
             var exception = CoreExceptionHelper.CreateMongoCommandException(-1);
             if (hasRetryableWriteLabel)

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/RetryableWriteTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/RetryableWriteTestRunner.cs
@@ -80,7 +80,12 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes
             var collection = database.GetCollection<BsonDocument>(_collectionName);
 
             database.DropCollection(collection.CollectionNamespace.CollectionName);
-            collection.InsertMany(definition["data"].AsBsonArray.Cast<BsonDocument>());
+            if (definition.TryGetValue("data", out var data) && 
+                data is BsonArray dataArray &&
+                dataArray.Count > 0)
+            {
+                collection.InsertMany(dataArray.Cast<BsonDocument>());
+            }
         }
 
         private void RunTest(BsonDocument test, bool async)

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-errorLabels.json
@@ -1,0 +1,182 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 1,
+          "insertedCount": 1,
+          "insertedIds": {
+            "1": 3
+          },
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/bulkWrite-errorLabels.yml
@@ -1,0 +1,77 @@
+runOn:
+    - minServerVersion: "4.3.1"
+      topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    - description: "BulkWrite succeeds with RetryableWriteError from server"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["update"]
+              errorCode: 112 # WriteConflict, not a retryable error code
+              errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+      operation:
+          name: "bulkWrite"
+          arguments:
+              requests:
+                  - name: "deleteOne"
+                    arguments:
+                        filter: { _id: 1 }
+                  - name: "insertOne"
+                    arguments:
+                        document: { _id: 3, x: 33 }
+                  - name: "updateOne"
+                    arguments:
+                        filter: { _id: 2 }
+                        update: { $inc: { x: 1 } }
+              options: { ordered: true }
+      outcome: # Driver retries operation and it succeeds
+          result:
+              deletedCount: 1
+              insertedCount: 1
+              insertedIds: { 1: 3 }
+              matchedCount: 1
+              modifiedCount: 1
+              upsertedCount: 0
+              upsertedIds: {}
+          collection:
+              data:
+                  - { _id: 2, x: 23 }
+                  - { _id: 3, x: 33 }
+
+    - description: "BulkWrite fails if server does not return RetryableWriteError"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["update"]
+              errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+              errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+      operation:
+          name: "bulkWrite"
+          arguments:
+              requests:
+                  - name: "deleteOne"
+                    arguments:
+                        filter: { _id: 1 }
+                  - name: "insertOne"
+                    arguments:
+                        document: { _id: 3, x: 33 }
+                  - name: "updateOne"
+                    arguments:
+                        filter: { _id: 2 }
+                        update: { $inc: { x: 1 } }
+              options: { ordered: true }
+      outcome:
+          error: true # Driver does not retry operation because there was no RetryableWriteError label on response
+          result:
+              errorLabelsOmit: ["RetryableWriteError"]
+          collection:
+              data:
+                  - { _id: 2, x: 22 }
+                  - { _id: 3, x: 33 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-errorLabels.json
@@ -1,14 +1,9 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0",
+      "minServerVersion": "4.3.1",
       "topology": [
-        "replicaset"
-      ]
-    },
-    {
-      "minServerVersion": "4.1.7",
-      "topology": [
+        "replicaset",
         "sharded"
       ]
     }
@@ -25,7 +20,7 @@
   ],
   "tests": [
     {
-      "description": "DeleteOne succeeds after PrimarySteppedDown",
+      "description": "DeleteOne succeeds with RetryableWriteError from server",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -35,7 +30,7 @@
           "failCommands": [
             "delete"
           ],
-          "errorCode": 189,
+          "errorCode": 112,
           "errorLabels": [
             "RetryableWriteError"
           ]
@@ -64,7 +59,7 @@
       }
     },
     {
-      "description": "DeleteOne succeeds after WriteConcernError ShutdownInProgress",
+      "description": "DeleteOne fails if server does not return RetryableWriteError",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -74,49 +69,8 @@
           "failCommands": [
             "delete"
           ],
-          "writeConcernError": {
-            "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
-          }
-        }
-      },
-      "operation": {
-        "name": "deleteOne",
-        "arguments": {
-          "filter": {
-            "_id": 1
-          }
-        }
-      },
-      "outcome": {
-        "result": {
-          "deletedCount": 1
-        },
-        "collection": {
-          "data": [
-            {
-              "_id": 2,
-              "x": 22
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "DeleteOne fails with RetryableWriteError label after two connection failures",
-      "failPoint": {
-        "configureFailPoint": "failCommand",
-        "mode": {
-          "times": 2
-        },
-        "data": {
-          "failCommands": [
-            "delete"
-          ],
-          "closeConnection": true
+          "errorCode": 11600,
+          "errorLabels": []
         }
       },
       "operation": {
@@ -130,7 +84,7 @@
       "outcome": {
         "error": true,
         "result": {
-          "errorLabelsContain": [
+          "errorLabelsOmit": [
             "RetryableWriteError"
           ]
         },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-errorLabels.yml
@@ -1,0 +1,48 @@
+runOn:
+    - minServerVersion: "4.3.1"
+      topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    - description: "DeleteOne succeeds with RetryableWriteError from server"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["delete"]
+              errorCode: 112 # WriteConflict, not a retryable error code
+              errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+      operation:
+          name: "deleteOne"
+          arguments:
+              filter: { _id: 1 }
+      outcome: # Driver retries operation and it succeeds
+          result:
+              deletedCount: 1
+          collection:
+              data:
+                  - { _id: 2, x: 22 }
+
+    - description: "DeleteOne fails if server does not return RetryableWriteError"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["delete"]
+              errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+              errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+      operation:
+          name: "deleteOne"
+          arguments:
+              filter: { _id: 1 }
+      outcome:
+          error: true # Driver does not retry operation because there was no RetryableWriteError label on response
+          result:
+              errorLabelsOmit: ["RetryableWriteError"]
+          collection:
+              data:
+                  - { _id: 1, x: 11 }
+                  - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/deleteOne-serverErrors.yml
@@ -19,6 +19,7 @@ tests:
             data:
                 failCommands: ["delete"]
                 errorCode: 189
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "deleteOne"
             arguments:
@@ -39,6 +40,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "deleteOne"
             arguments:
@@ -48,4 +50,24 @@ tests:
                 deletedCount: 1
             collection:
                 data:
+                    - { _id: 2, x: 22 }
+    -
+        description: "DeleteOne fails with RetryableWriteError label after two connection failures"
+        failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+                failCommands: ["delete"]
+                closeConnection: true
+        operation:
+            name: "deleteOne"
+            arguments:
+                filter: { _id: 1 }
+        outcome:
+            error: true
+            result:
+                errorLabelsContain: ["RetryableWriteError"]
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-errorLabels.json
@@ -1,14 +1,9 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0",
+      "minServerVersion": "4.3.1",
       "topology": [
-        "replicaset"
-      ]
-    },
-    {
-      "minServerVersion": "4.1.7",
-      "topology": [
+        "replicaset",
         "sharded"
       ]
     }
@@ -25,7 +20,7 @@
   ],
   "tests": [
     {
-      "description": "FindOneAndDelete succeeds after PrimarySteppedDown",
+      "description": "FindOneAndDelete succeeds with RetryableWriteError from server",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -35,7 +30,7 @@
           "failCommands": [
             "findAndModify"
           ],
-          "errorCode": 189,
+          "errorCode": 112,
           "errorLabels": [
             "RetryableWriteError"
           ]
@@ -70,7 +65,7 @@
       }
     },
     {
-      "description": "FindOneAndDelete succeeds after WriteConcernError ShutdownInProgress",
+      "description": "FindOneAndDelete fails if server does not return RetryableWriteError",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -80,55 +75,8 @@
           "failCommands": [
             "findAndModify"
           ],
-          "writeConcernError": {
-            "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
-          }
-        }
-      },
-      "operation": {
-        "name": "findOneAndDelete",
-        "arguments": {
-          "filter": {
-            "x": {
-              "$gte": 11
-            }
-          },
-          "sort": {
-            "x": 1
-          }
-        }
-      },
-      "outcome": {
-        "result": {
-          "_id": 1,
-          "x": 11
-        },
-        "collection": {
-          "data": [
-            {
-              "_id": 2,
-              "x": 22
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "FindOneAndDelete fails with a RetryableWriteError label after two connection failures",
-      "failPoint": {
-        "configureFailPoint": "failCommand",
-        "mode": {
-          "times": 2
-        },
-        "data": {
-          "failCommands": [
-            "findAndModify"
-          ],
-          "closeConnection": true
+          "errorCode": 11600,
+          "errorLabels": []
         }
       },
       "operation": {
@@ -147,7 +95,7 @@
       "outcome": {
         "error": true,
         "result": {
-          "errorLabelsContain": [
+          "errorLabelsOmit": [
             "RetryableWriteError"
           ]
         },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-errorLabels.yml
@@ -1,0 +1,49 @@
+runOn:
+    - minServerVersion: "4.3.1"
+      topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    - description: "FindOneAndDelete succeeds with RetryableWriteError from server"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["findAndModify"]
+              errorCode: 112 # WriteConflict, not a retryable error code
+              errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+      operation:
+          name: "findOneAndDelete"
+          arguments:
+              filter: { x: { $gte: 11 } }
+              sort: { x: 1 }
+      outcome: # Driver retries operation and it succeeds
+          result: { _id: 1, x: 11 }
+          collection:
+              data:
+                  - { _id: 2, x: 22 }
+
+    - description: "FindOneAndDelete fails if server does not return RetryableWriteError"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["findAndModify"]
+              errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+              errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+      operation:
+          name: "findOneAndDelete"
+          arguments:
+              filter: { x: { $gte: 11 } }
+              sort: { x: 1 }
+      outcome:
+          error: true # Driver does not retry operation because there was no RetryableWriteError label on response
+          result:
+              errorLabelsOmit: ["RetryableWriteError"]
+          collection:
+              data:
+                  - { _id: 1, x: 11 }
+                  - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndDelete-serverErrors.yml
@@ -19,6 +19,7 @@ tests:
             data:
                 failCommands: ["findAndModify"]
                 errorCode: 189
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "findOneAndDelete"
             arguments:
@@ -39,6 +40,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "findOneAndDelete"
             arguments:
@@ -48,4 +50,25 @@ tests:
             result: { _id: 1, x: 11 }
             collection:
                 data:
+                    - { _id: 2, x: 22 }
+    -
+        description: "FindOneAndDelete fails with a RetryableWriteError label after two connection failures"
+        failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+                failCommands: ["findAndModify"]
+                closeConnection: true
+        operation:
+            name: "findOneAndDelete"
+            arguments:
+                filter: { x: { $gte: 11 } }
+                sort: { x: 1 }
+        outcome:
+            error: true
+            result:
+                errorLabelsContain: ["RetryableWriteError"]
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-errorLabels.json
@@ -1,14 +1,9 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0",
+      "minServerVersion": "4.3.1",
       "topology": [
-        "replicaset"
-      ]
-    },
-    {
-      "minServerVersion": "4.1.7",
-      "topology": [
+        "replicaset",
         "sharded"
       ]
     }
@@ -25,7 +20,7 @@
   ],
   "tests": [
     {
-      "description": "FindOneAndReplace succeeds after PrimarySteppedDown",
+      "description": "FindOneAndReplace succeeds with RetryableWriteError from server",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -35,7 +30,7 @@
           "failCommands": [
             "findAndModify"
           ],
-          "errorCode": 189,
+          "errorCode": 112,
           "errorLabels": [
             "RetryableWriteError"
           ]
@@ -74,7 +69,7 @@
       }
     },
     {
-      "description": "FindOneAndReplace succeeds after WriteConcernError ShutdownInProgress",
+      "description": "FindOneAndReplace fails if server does not return RetryableWriteError",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -84,59 +79,8 @@
           "failCommands": [
             "findAndModify"
           ],
-          "writeConcernError": {
-            "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
-          }
-        }
-      },
-      "operation": {
-        "name": "findOneAndReplace",
-        "arguments": {
-          "filter": {
-            "_id": 1
-          },
-          "replacement": {
-            "_id": 1,
-            "x": 111
-          },
-          "returnDocument": "Before"
-        }
-      },
-      "outcome": {
-        "result": {
-          "_id": 1,
-          "x": 11
-        },
-        "collection": {
-          "data": [
-            {
-              "_id": 1,
-              "x": 111
-            },
-            {
-              "_id": 2,
-              "x": 22
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "FindOneAndReplace fails with a RetryableWriteError label after two connection failures",
-      "failPoint": {
-        "configureFailPoint": "failCommand",
-        "mode": {
-          "times": 2
-        },
-        "data": {
-          "failCommands": [
-            "findAndModify"
-          ],
-          "closeConnection": true
+          "errorCode": 11600,
+          "errorLabels": []
         }
       },
       "operation": {
@@ -155,7 +99,7 @@
       "outcome": {
         "error": true,
         "result": {
-          "errorLabelsContain": [
+          "errorLabelsOmit": [
             "RetryableWriteError"
           ]
         },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-errorLabels.yml
@@ -1,0 +1,52 @@
+runOn:
+    - minServerVersion: "4.3.1"
+      topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    - description: "FindOneAndReplace succeeds with RetryableWriteError from server"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["findAndModify"]
+              errorCode: 112 # WriteConflict, not a retryable error code
+              errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+      operation:
+          name: "findOneAndReplace"
+          arguments:
+              filter: { _id: 1 }
+              replacement: { _id: 1, x: 111 }
+              returnDocument: "Before"
+      outcome: # Driver retries operation and it succeeds
+          result: { _id: 1, x: 11 }
+          collection:
+              data:
+                  - { _id: 1, x: 111 }
+                  - { _id: 2, x: 22 }
+
+    - description: "FindOneAndReplace fails if server does not return RetryableWriteError"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["findAndModify"]
+              errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+              errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+      operation:
+          name: "findOneAndReplace"
+          arguments:
+              filter: { _id: 1 }
+              replacement: { _id: 1, x: 111 }
+              returnDocument: "Before"
+      outcome:
+          error: true # Driver does not retry operation because there was no RetryableWriteError label on response
+          result:
+              errorLabelsOmit: ["RetryableWriteError"]
+          collection:
+              data:
+                  - { _id: 1, x: 11 }
+                  - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndReplace-serverErrors.yml
@@ -19,6 +19,7 @@ tests:
             data:
                 failCommands: ["findAndModify"]
                 errorCode: 189
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "findOneAndReplace"
             arguments:
@@ -41,6 +42,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "findOneAndReplace"
             arguments:
@@ -52,4 +54,27 @@ tests:
             collection:
                 data:
                     - { _id: 1, x: 111 }
+                    - { _id: 2, x: 22 }
+
+    -
+        description: "FindOneAndReplace fails with a RetryableWriteError label after two connection failures"
+        failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+                failCommands: ["findAndModify"]
+                closeConnection: true
+        operation:
+            name: "findOneAndReplace"
+            arguments:
+                filter: { _id: 1 }
+                replacement: { _id: 1, x: 111 }
+                returnDocument: "Before"
+        outcome:
+            error: true
+            result:
+                errorLabelsContain: ["RetryableWriteError"]
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-errorLabels.json
@@ -1,14 +1,9 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0",
+      "minServerVersion": "4.3.1",
       "topology": [
-        "replicaset"
-      ]
-    },
-    {
-      "minServerVersion": "4.1.7",
-      "topology": [
+        "replicaset",
         "sharded"
       ]
     }
@@ -25,7 +20,7 @@
   ],
   "tests": [
     {
-      "description": "DeleteOne succeeds after PrimarySteppedDown",
+      "description": "FindOneAndUpdate succeeds with RetryableWriteError from server",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -33,28 +28,39 @@
         },
         "data": {
           "failCommands": [
-            "delete"
+            "findAndModify"
           ],
-          "errorCode": 189,
+          "errorCode": 112,
           "errorLabels": [
             "RetryableWriteError"
           ]
         }
       },
       "operation": {
-        "name": "deleteOne",
+        "name": "findOneAndUpdate",
         "arguments": {
           "filter": {
             "_id": 1
-          }
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          },
+          "returnDocument": "Before"
         }
       },
       "outcome": {
         "result": {
-          "deletedCount": 1
+          "_id": 1,
+          "x": 11
         },
         "collection": {
           "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
             {
               "_id": 2,
               "x": 22
@@ -64,7 +70,7 @@
       }
     },
     {
-      "description": "DeleteOne succeeds after WriteConcernError ShutdownInProgress",
+      "description": "FindOneAndUpdate fails if server does not return RetryableWriteError",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -72,65 +78,30 @@
         },
         "data": {
           "failCommands": [
-            "delete"
+            "findAndModify"
           ],
-          "writeConcernError": {
-            "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
-          }
+          "errorCode": 11600,
+          "errorLabels": []
         }
       },
       "operation": {
-        "name": "deleteOne",
+        "name": "findOneAndUpdate",
         "arguments": {
           "filter": {
             "_id": 1
-          }
-        }
-      },
-      "outcome": {
-        "result": {
-          "deletedCount": 1
-        },
-        "collection": {
-          "data": [
-            {
-              "_id": 2,
-              "x": 22
+          },
+          "update": {
+            "$inc": {
+              "x": 1
             }
-          ]
-        }
-      }
-    },
-    {
-      "description": "DeleteOne fails with RetryableWriteError label after two connection failures",
-      "failPoint": {
-        "configureFailPoint": "failCommand",
-        "mode": {
-          "times": 2
-        },
-        "data": {
-          "failCommands": [
-            "delete"
-          ],
-          "closeConnection": true
-        }
-      },
-      "operation": {
-        "name": "deleteOne",
-        "arguments": {
-          "filter": {
-            "_id": 1
-          }
+          },
+          "returnDocument": "Before"
         }
       },
       "outcome": {
         "error": true,
         "result": {
-          "errorLabelsContain": [
+          "errorLabelsOmit": [
             "RetryableWriteError"
           ]
         },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-errorLabels.yml
@@ -1,0 +1,52 @@
+runOn:
+    - minServerVersion: "4.3.1"
+      topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    - description: "FindOneAndUpdate succeeds with RetryableWriteError from server"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["findAndModify"]
+              errorCode: 112 # WriteConflict, not a retryable error code
+              errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+      operation:
+          name: "findOneAndUpdate"
+          arguments:
+              filter: { _id: 1 }
+              update: { $inc: { x: 1 } }
+              returnDocument: "Before"
+      outcome: # Driver retries operation and it succeeds
+          result: { _id: 1, x: 11 }
+          collection:
+              data:
+                  - { _id: 1, x: 12 }
+                  - { _id: 2, x: 22 }
+
+    - description: "FindOneAndUpdate fails if server does not return RetryableWriteError"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["findAndModify"]
+              errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+              errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+      operation:
+          name: "findOneAndUpdate"
+          arguments:
+              filter: { _id: 1 }
+              update: { $inc: { x: 1 } }
+              returnDocument: "Before"
+      outcome:
+          error: true # Driver does not retry operation because there was no RetryableWriteError label on response
+          result:
+              errorLabelsOmit: ["RetryableWriteError"]
+          collection:
+              data:
+                  - { _id: 1, x: 11 }
+                  - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "findAndModify"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -84,7 +87,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -112,6 +118,55 @@
             {
               "_id": 1,
               "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "findOneAndUpdate",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          },
+          "returnDocument": "Before"
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
             },
             {
               "_id": 2,

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
@@ -19,6 +19,7 @@ tests:
             data:
                 failCommands: ["findAndModify"]
                 errorCode: 189
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "findOneAndUpdate"
             arguments:
@@ -41,6 +42,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "findOneAndUpdate"
             arguments:
@@ -52,4 +54,26 @@ tests:
             collection:
                 data:
                     - { _id: 1, x: 12 }
+                    - { _id: 2, x: 22 }
+    -
+        description: "FindOneAndUpdate fails with a RetryableWriteError label after two connection failures"
+        failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+                failCommands: ["findAndModify"]
+                closeConnection: true
+        operation:
+            name: "findOneAndUpdate"
+            arguments:
+                filter: { _id: 1 }
+                update: { $inc: { x: 1 } }
+                returnDocument: "Before"
+        outcome:
+            error: true
+            result:
+                errorLabelsContain: ["RetryableWriteError"]
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-errorLabels.json
@@ -1,14 +1,9 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0",
+      "minServerVersion": "4.3.1",
       "topology": [
-        "replicaset"
-      ]
-    },
-    {
-      "minServerVersion": "4.1.7",
-      "topology": [
+        "replicaset",
         "sharded"
       ]
     }
@@ -21,7 +16,7 @@
   ],
   "tests": [
     {
-      "description": "InsertMany succeeds after PrimarySteppedDown",
+      "description": "InsertMany succeeds with RetryableWriteError from server",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -31,7 +26,7 @@
           "failCommands": [
             "insert"
           ],
-          "errorCode": 189,
+          "errorCode": 112,
           "errorLabels": [
             "RetryableWriteError"
           ]
@@ -81,7 +76,7 @@
       }
     },
     {
-      "description": "InsertMany succeeds after WriteConcernError ShutdownInProgress",
+      "description": "InsertMany fails if server does not return RetryableWriteError",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -91,70 +86,8 @@
           "failCommands": [
             "insert"
           ],
-          "writeConcernError": {
-            "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
-          }
-        }
-      },
-      "operation": {
-        "name": "insertMany",
-        "arguments": {
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
-            }
-          ],
-          "options": {
-            "ordered": true
-          }
-        }
-      },
-      "outcome": {
-        "result": {
-          "insertedIds": {
-            "0": 2,
-            "1": 3
-          }
-        },
-        "collection": {
-          "data": [
-            {
-              "_id": 1,
-              "x": 11
-            },
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "InsertMany fails with a RetryableWriteError label after two connection failures",
-      "failPoint": {
-        "configureFailPoint": "failCommand",
-        "mode": {
-          "times": 2
-        },
-        "data": {
-          "failCommands": [
-            "insert"
-          ],
-          "closeConnection": true
+          "errorCode": 11600,
+          "errorLabels": []
         }
       },
       "operation": {
@@ -178,7 +111,7 @@
       "outcome": {
         "error": true,
         "result": {
-          "errorLabelsContain": [
+          "errorLabelsOmit": [
             "RetryableWriteError"
           ]
         },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-errorLabels.yml
@@ -1,0 +1,54 @@
+runOn:
+    - minServerVersion: "4.3.1"
+      topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+
+tests:
+    - description: "InsertMany succeeds with RetryableWriteError from server"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["insert"]
+              errorCode: 112 # WriteConflict, not a retryable error code
+              errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+      operation:
+          name: "insertMany"
+          arguments:
+              documents:
+                  - { _id: 2, x: 22 }
+                  - { _id: 3, x: 33 }
+              options: { ordered: true }
+      outcome: # Driver retries operation and it succeeds
+          result:
+              insertedIds: { 0: 2, 1: 3 }
+          collection:
+              data:
+                  - { _id: 1, x: 11 }
+                  - { _id: 2, x: 22 }
+                  - { _id: 3, x: 33 }
+
+    - description: "InsertMany fails if server does not return RetryableWriteError"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["insert"]
+              errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+              errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+      operation:
+          name: "insertMany"
+          arguments:
+              documents:
+                  - { _id: 2, x: 22 }
+                  - { _id: 3, x: 33 }
+              options: { ordered: true }
+      outcome:
+          error: true # Driver does not retry operation because there was no RetryableWriteError label on response
+          result:
+              errorLabelsOmit: ["RetryableWriteError"]
+          collection:
+              data:
+                  - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertMany-serverErrors.yml
@@ -18,6 +18,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 189
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "insertMany"
             arguments:
@@ -43,6 +44,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "insertMany"
             arguments:
@@ -58,3 +60,25 @@ tests:
                     - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
+    -
+        description: "InsertMany fails with a RetryableWriteError label after two connection failures"
+        failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+                failCommands: ["insert"]
+                closeConnection: true
+        operation:
+            name: "insertMany"
+            arguments:
+                documents:
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }
+                options: { ordered: true }
+        outcome:
+            error: true
+            result:
+                errorLabelsContain: ["RetryableWriteError"]
+            collection:
+                data:
+                    - { _id: 1, x: 11 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-errorLabels.json
@@ -1,0 +1,90 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [],
+  "tests": [
+    {
+      "description": "InsertOne succeeds with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operation": {
+        "name": "insertOne",
+        "arguments": {
+          "document": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "insertedId": 1
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertOne fails if server does not return RetryableWriteError",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operation": {
+        "name": "insertOne",
+        "arguments": {
+          "document": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-errorLabels.yml
@@ -1,0 +1,44 @@
+runOn:
+    - minServerVersion: "4.3.1"
+      topology: ["replicaset", "sharded"]
+
+data: []
+
+tests:
+    - description: "InsertOne succeeds with RetryableWriteError from server"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["insert"]
+              errorCode: 112 # WriteConflict, not a retryable error code
+              errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+      operation:
+          name: "insertOne"
+          arguments:
+              document: { _id: 1, x: 11 }
+      outcome: # Driver retries operation and it succeeds
+          result:
+              insertedId: 1
+          collection:
+              data:
+                  - { _id: 1, x: 11 }
+
+    - description: "InsertOne fails if server does not return RetryableWriteError"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["insert"]
+              errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+              errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+      operation:
+          name: "insertOne"
+          arguments:
+              document: { _id: 1, x: 11 }
+      outcome:
+          error: true # Driver does not retry operation because there was no RetryableWriteError label on response
+          result:
+              errorLabelsOmit: ["RetryableWriteError"]
+          collection:
+              data: []

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.json
@@ -81,6 +81,9 @@
             "insert"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -127,6 +130,9 @@
             "insert"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -173,6 +179,9 @@
             "insert"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -219,6 +228,9 @@
             "insert"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -265,6 +277,9 @@
             "insert"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -311,6 +326,9 @@
             "insert"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -357,6 +375,9 @@
             "insert"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -403,6 +424,9 @@
             "insert"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -449,6 +473,9 @@
             "insert"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -495,6 +522,9 @@
             "insert"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -541,6 +571,58 @@
             "insert"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
+          "closeConnection": false
+        }
+      },
+      "operation": {
+        "name": "insertOne",
+        "arguments": {
+          "document": {
+            "_id": 3,
+            "x": 33
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "insertedId": 3
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertOne succeeds after ExceededTimeLimit",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "errorCode": 262,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -601,6 +683,11 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
         "collection": {
           "data": [
             {
@@ -628,7 +715,10 @@
           ],
           "writeConcernError": {
             "code": 11600,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -676,7 +766,10 @@
           ],
           "writeConcernError": {
             "code": 11602,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -724,7 +817,10 @@
           ],
           "writeConcernError": {
             "code": 189,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -772,7 +868,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -835,6 +934,11 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
         "collection": {
           "data": [
             {
@@ -881,6 +985,11 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
         "collection": {
           "data": [
             {
@@ -931,6 +1040,11 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
         "collection": {
           "data": [
             {
@@ -944,6 +1058,50 @@
             {
               "_id": 3,
               "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertOne fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "insertOne",
+        "arguments": {
+          "document": {
+            "_id": 3,
+            "x": 33
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
             }
           ]
         }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/insertOne-serverErrors.yml
@@ -39,6 +39,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 10107
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -60,6 +61,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 13436
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -81,6 +83,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 13435
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -102,6 +105,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 11602
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -123,6 +127,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 11600
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -144,6 +149,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 189
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -165,6 +171,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 91
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -186,6 +193,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 7
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -207,6 +215,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 6
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -228,6 +237,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 9001
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -249,6 +259,29 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 89
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                closeConnection: false
+        operation:
+            name: "insertOne"
+            arguments:
+                document: { _id: 3, x: 33 }
+        outcome:
+            result:
+                insertedId: 3
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }
+    -
+        description: "InsertOne succeeds after ExceededTimeLimit"
+        failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+                failCommands: ["insert"]
+                errorCode: 262
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -277,6 +310,8 @@ tests:
                 document: { _id: 3, x: 33 }
         outcome:
             error: true
+            result:
+                errorLabelsOmit: ["RetryableWriteError"]
             collection:
                 data:
                     - { _id: 1, x: 11 }
@@ -291,6 +326,7 @@ tests:
                 writeConcernError:
                     code: 11600
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "insertOne"
             arguments:
@@ -313,6 +349,7 @@ tests:
                 writeConcernError:
                     code: 11602
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "insertOne"
             arguments:
@@ -335,6 +372,7 @@ tests:
                 writeConcernError:
                     code: 189
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "insertOne"
             arguments:
@@ -357,6 +395,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "insertOne"
             arguments:
@@ -385,6 +424,8 @@ tests:
                 document: { _id: 3, x: 33 }
         outcome:
             error: true
+            result:
+                errorLabelsContain: ["RetryableWriteError"]
             collection:
                 data:
                     - { _id: 1, x: 11 }
@@ -406,6 +447,8 @@ tests:
                 document: { _id: 3, x: 33 }
         outcome:
             error: true
+            result:
+                errorLabelsOmit: ["RetryableWriteError"]
             collection:
                 data:
                     - { _id: 1, x: 11 }
@@ -429,8 +472,31 @@ tests:
                 document: { _id: 3, x: 33 }
         outcome:
             error: true
+            result:
+                errorLabelsOmit: ["RetryableWriteError"]
             collection:
                 data:
                     - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }  # The write was still applied.
+
+    -
+        description: "InsertOne fails with a RetryableWriteError label after two connection failures"
+        failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+                failCommands: ["insert"]
+                closeConnection: true
+        operation:
+            name: "insertOne"
+            arguments:
+                document: { _id: 3, x: 33 }
+        outcome:
+            error: true
+            result:
+                errorLabelsContain: ["RetryableWriteError"]
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
+                    - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-errorLabels.json
@@ -1,14 +1,9 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0",
+      "minServerVersion": "4.3.1",
       "topology": [
-        "replicaset"
-      ]
-    },
-    {
-      "minServerVersion": "4.1.7",
-      "topology": [
+        "replicaset",
         "sharded"
       ]
     }
@@ -25,7 +20,7 @@
   ],
   "tests": [
     {
-      "description": "DeleteOne succeeds after PrimarySteppedDown",
+      "description": "ReplaceOne succeeds with RetryableWriteError from server",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -33,28 +28,38 @@
         },
         "data": {
           "failCommands": [
-            "delete"
+            "update"
           ],
-          "errorCode": 189,
+          "errorCode": 112,
           "errorLabels": [
             "RetryableWriteError"
           ]
         }
       },
       "operation": {
-        "name": "deleteOne",
+        "name": "replaceOne",
         "arguments": {
           "filter": {
             "_id": 1
+          },
+          "replacement": {
+            "_id": 1,
+            "x": 111
           }
         }
       },
       "outcome": {
         "result": {
-          "deletedCount": 1
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [
+            {
+              "_id": 1,
+              "x": 111
+            },
             {
               "_id": 2,
               "x": 22
@@ -64,7 +69,7 @@
       }
     },
     {
-      "description": "DeleteOne succeeds after WriteConcernError ShutdownInProgress",
+      "description": "ReplaceOne fails if server does not return RetryableWriteError",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -72,65 +77,28 @@
         },
         "data": {
           "failCommands": [
-            "delete"
+            "update"
           ],
-          "writeConcernError": {
-            "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
-          }
+          "errorCode": 11600,
+          "errorLabels": []
         }
       },
       "operation": {
-        "name": "deleteOne",
+        "name": "replaceOne",
         "arguments": {
           "filter": {
             "_id": 1
-          }
-        }
-      },
-      "outcome": {
-        "result": {
-          "deletedCount": 1
-        },
-        "collection": {
-          "data": [
-            {
-              "_id": 2,
-              "x": 22
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "DeleteOne fails with RetryableWriteError label after two connection failures",
-      "failPoint": {
-        "configureFailPoint": "failCommand",
-        "mode": {
-          "times": 2
-        },
-        "data": {
-          "failCommands": [
-            "delete"
-          ],
-          "closeConnection": true
-        }
-      },
-      "operation": {
-        "name": "deleteOne",
-        "arguments": {
-          "filter": {
-            "_id": 1
+          },
+          "replacement": {
+            "_id": 1,
+            "x": 111
           }
         }
       },
       "outcome": {
         "error": true,
         "result": {
-          "errorLabelsContain": [
+          "errorLabelsOmit": [
             "RetryableWriteError"
           ]
         },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-errorLabels.yml
@@ -1,0 +1,53 @@
+runOn:
+    - minServerVersion: "4.3.1"
+      topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    - description: "ReplaceOne succeeds with RetryableWriteError from server"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["update"]
+              errorCode: 112 # WriteConflict, not a retryable error code
+              errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+      operation:
+          name: "replaceOne"
+          arguments:
+              filter: { _id: 1 }
+              replacement: { _id: 1, x: 111 }
+      outcome: # Driver retries operation and it succeeds
+          result:
+              matchedCount: 1
+              modifiedCount: 1
+              upsertedCount: 0
+          collection:
+              data:
+                  - { _id: 1, x: 111 }
+                  - { _id: 2, x: 22 }
+
+    - description: "ReplaceOne fails if server does not return RetryableWriteError"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["update"]
+              errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+              errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+      operation:
+          name: "replaceOne"
+          arguments:
+              filter: { _id: 1 }
+              replacement: { _id: 1, x: 111 }
+      outcome:
+          error: true # Driver does not retry operation because there was no RetryableWriteError label on response
+          result:
+              errorLabelsOmit: ["RetryableWriteError"]
+          collection:
+              data:
+                  - { _id: 1, x: 11 }
+                  - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "update"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -83,7 +86,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -110,6 +116,53 @@
             {
               "_id": 1,
               "x": 111
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ReplaceOne fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "replaceOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "replacement": {
+            "_id": 1,
+            "x": 111
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
             },
             {
               "_id": 2,

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/replaceOne-serverErrors.yml
@@ -19,6 +19,7 @@ tests:
             data:
                 failCommands: ["update"]
                 errorCode: 189
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "replaceOne"
             arguments:
@@ -43,6 +44,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "replaceOne"
             arguments:
@@ -56,4 +58,25 @@ tests:
             collection:
                 data:
                     - { _id: 1, x: 111 }
+                    - { _id: 2, x: 22 }
+    -
+        description: "ReplaceOne fails with a RetryableWriteError label after two connection failures"
+        failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+                failCommands: ["update"]
+                closeConnection: true
+        operation:
+            name: "replaceOne"
+            arguments:
+                filter: { _id: 1 }
+                replacement: { _id: 1, x: 111 }
+        outcome:
+            error: true
+            result:
+                errorLabelsContain: ["RetryableWriteError"]
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-errorLabels.json
@@ -1,14 +1,9 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0",
+      "minServerVersion": "4.3.1",
       "topology": [
-        "replicaset"
-      ]
-    },
-    {
-      "minServerVersion": "4.1.7",
-      "topology": [
+        "replicaset",
         "sharded"
       ]
     }
@@ -25,7 +20,7 @@
   ],
   "tests": [
     {
-      "description": "DeleteOne succeeds after PrimarySteppedDown",
+      "description": "UpdateOne succeeds with RetryableWriteError from server",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -33,28 +28,39 @@
         },
         "data": {
           "failCommands": [
-            "delete"
+            "update"
           ],
-          "errorCode": 189,
+          "errorCode": 112,
           "errorLabels": [
             "RetryableWriteError"
           ]
         }
       },
       "operation": {
-        "name": "deleteOne",
+        "name": "updateOne",
         "arguments": {
           "filter": {
             "_id": 1
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
           }
         }
       },
       "outcome": {
         "result": {
-          "deletedCount": 1
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
             {
               "_id": 2,
               "x": 22
@@ -64,7 +70,7 @@
       }
     },
     {
-      "description": "DeleteOne succeeds after WriteConcernError ShutdownInProgress",
+      "description": "UpdateOne fails if server does not return RetryableWriteError",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -72,65 +78,29 @@
         },
         "data": {
           "failCommands": [
-            "delete"
+            "update"
           ],
-          "writeConcernError": {
-            "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
-          }
+          "errorCode": 11600,
+          "errorLabels": []
         }
       },
       "operation": {
-        "name": "deleteOne",
+        "name": "updateOne",
         "arguments": {
           "filter": {
             "_id": 1
-          }
-        }
-      },
-      "outcome": {
-        "result": {
-          "deletedCount": 1
-        },
-        "collection": {
-          "data": [
-            {
-              "_id": 2,
-              "x": 22
+          },
+          "update": {
+            "$inc": {
+              "x": 1
             }
-          ]
-        }
-      }
-    },
-    {
-      "description": "DeleteOne fails with RetryableWriteError label after two connection failures",
-      "failPoint": {
-        "configureFailPoint": "failCommand",
-        "mode": {
-          "times": 2
-        },
-        "data": {
-          "failCommands": [
-            "delete"
-          ],
-          "closeConnection": true
-        }
-      },
-      "operation": {
-        "name": "deleteOne",
-        "arguments": {
-          "filter": {
-            "_id": 1
           }
         }
       },
       "outcome": {
         "error": true,
         "result": {
-          "errorLabelsContain": [
+          "errorLabelsOmit": [
             "RetryableWriteError"
           ]
         },

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-errorLabels.yml
@@ -1,0 +1,53 @@
+runOn:
+    - minServerVersion: "4.3.1"
+      topology: ["replicaset", "sharded"]
+
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+tests:
+    - description: "UpdateOne succeeds with RetryableWriteError from server"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["update"]
+              errorCode: 112 # WriteConflict, not a retryable error code
+              errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+      operation:
+          name: "updateOne"
+          arguments:
+              filter: { _id: 1 }
+              update: { $inc: { x: 1 } }
+      outcome: # Driver retries operation and it succeeds
+          result:
+              matchedCount: 1
+              modifiedCount: 1
+              upsertedCount: 0
+          collection:
+              data:
+                  - { _id: 1, x: 12 }
+                  - { _id: 2, x: 22 }
+
+    - description: "UpdateOne fails if server does not return RetryableWriteError"
+      failPoint:
+          configureFailPoint: failCommand
+          mode: { times: 1 }
+          data:
+              failCommands: ["update"]
+              errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+              errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+      operation:
+          name: "updateOne"
+          arguments:
+              filter: { _id: 1 }
+              update: { $inc: { x: 1 } }
+      outcome:
+          error: true # Driver does not retry operation because there was no RetryableWriteError label on response
+          result:
+              errorLabelsOmit: ["RetryableWriteError"]
+          collection:
+              data:
+                  - { _id: 1, x: 11 }
+                  - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.json
@@ -35,7 +35,10 @@
           "failCommands": [
             "update"
           ],
-          "errorCode": 189
+          "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operation": {
@@ -84,7 +87,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -112,6 +118,54 @@
             {
               "_id": 1,
               "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateOne fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "updateOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
             },
             {
               "_id": 2,

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/tests/updateOne-serverErrors.yml
@@ -19,6 +19,7 @@ tests:
             data:
                 failCommands: ["update"]
                 errorCode: 189
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "updateOne"
             arguments:
@@ -43,6 +44,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
+                    errorLabels: ["RetryableWriteError"] # SPEC-1565
         operation:
             name: "updateOne"
             arguments:
@@ -56,4 +58,25 @@ tests:
             collection:
                 data:
                     - { _id: 1, x: 12 }
+                    - { _id: 2, x: 22 }
+    -
+        description: "UpdateOne fails with a RetryableWriteError label after two connection failures"
+        failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+                failCommands: ["update"]
+                closeConnection: true
+        operation:
+            name: "updateOne"
+            arguments:
+                filter: { _id: 1 }
+                update: { $inc: { x: 1 } }
+        outcome:
+            error: true
+            result:
+                errorLabelsContain: ["RetryableWriteError"]
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
                     - { _id: 2, x: 22 }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/error-labels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/error-labels.json
@@ -42,7 +42,8 @@
             "errorLabelsOmit": [
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
-            ]
+            ],
+            "errorContains": "E11000"
           }
         },
         {
@@ -407,6 +408,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -460,7 +462,7 @@
       }
     },
     {
-      "description": "add transient label to connection errors",
+      "description": "add TransientTransactionError label to connection errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -662,7 +664,7 @@
       }
     },
     {
-      "description": "add unknown commit label to connection errors",
+      "description": "add RetryableWriteError and UnknownTransactionCommitResult labels to connection errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -698,6 +700,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -800,7 +803,7 @@
       }
     },
     {
-      "description": "add unknown commit label to retryable commit errors",
+      "description": "add RetryableWriteError and UnknownTransactionCommitResult labels to retryable commit errors",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -810,7 +813,10 @@
           "failCommands": [
             "commitTransaction"
           ],
-          "errorCode": 11602
+          "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operations": [
@@ -836,6 +842,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -938,7 +945,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError ShutdownInProgress",
+      "description": "add RetryableWriteError and UnknownTransactionCommitResult labels to writeConcernError ShutdownInProgress",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -950,7 +957,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },
@@ -984,6 +994,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -1088,7 +1099,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError WriteConcernFailed",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1137,6 +1148,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }
@@ -1219,7 +1231,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError WriteConcernFailed with wtimeout",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed with wtimeout",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1272,6 +1284,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }
@@ -1354,7 +1367,7 @@
       }
     },
     {
-      "description": "omit unknown commit label to writeConcernError UnsatisfiableWriteConcern",
+      "description": "omit UnknownTransactionCommitResult label from writeConcernError UnsatisfiableWriteConcern",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1400,6 +1413,7 @@
           "object": "session0",
           "result": {
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
             ]
@@ -1460,7 +1474,7 @@
       }
     },
     {
-      "description": "omit unknown commit label to writeConcernError UnknownReplWriteConcern",
+      "description": "omit UnknownTransactionCommitResult label from writeConcernError UnknownReplWriteConcern",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1506,6 +1520,7 @@
           "object": "session0",
           "result": {
             "errorLabelsOmit": [
+              "RetryableWriteConcern",
               "TransientTransactionError",
               "UnknownTransactionCommitResult"
             ]
@@ -1566,7 +1581,7 @@
       }
     },
     {
-      "description": "do not add unknown commit label to MaxTimeMSExpired inside transactions",
+      "description": "do not add UnknownTransactionCommitResult label to MaxTimeMSExpired inside transactions",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1613,6 +1628,7 @@
           },
           "result": {
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult",
               "TransientTransactionError"
             ]
@@ -1695,7 +1711,7 @@
       }
     },
     {
-      "description": "add unknown commit label to MaxTimeMSExpired",
+      "description": "add UnknownTransactionCommitResult label to MaxTimeMSExpired",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1742,6 +1758,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }
@@ -1826,7 +1843,7 @@
       }
     },
     {
-      "description": "add unknown commit label to writeConcernError MaxTimeMSExpired",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError MaxTimeMSExpired",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1876,6 +1893,7 @@
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "TransientTransactionError"
             ]
           }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/error-labels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/error-labels.yml
@@ -25,10 +25,10 @@ tests:
             - _id: 1
             - _id: 1
         result:
-          # Don't assert on errorCodeName because (after SERVER-38583) the
-          # DuplicateKey is reported in writeErrors, not as a top-level
-          # command error.
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+          # DuplicateKey error code included in the bulk write error message
+          # returned by the server
+          errorContains: E11000
       - name: abortTransaction
         object: session0
 
@@ -261,7 +261,7 @@ tests:
         result:
           # Note, the server will return the errorLabel in this case.
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -295,7 +295,7 @@ tests:
       collection:
         data: []
 
-  - description: add transient label to connection errors
+  - description: add TransientTransactionError label to connection errors
 
     failPoint:
       configureFailPoint: failCommand
@@ -408,7 +408,7 @@ tests:
       collection:
         data: []
 
-  - description: add unknown commit label to connection errors
+  - description: add RetryableWriteError and UnknownTransactionCommitResult labels to connection errors
 
     failPoint:
       configureFailPoint: failCommand
@@ -431,7 +431,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       - name: commitTransaction
         object: session0
@@ -492,14 +492,15 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to retryable commit errors
+  - description: add RetryableWriteError and UnknownTransactionCommitResult labels to retryable commit errors
 
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
           failCommands: ["commitTransaction"]
-          errorCode: 11602  # InterruptedDueToStepDown 
+          errorCode: 11602  # InterruptedDueToReplStateChange
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
 
     operations:
       - name: startTransaction
@@ -515,7 +516,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       - name: commitTransaction
         object: session0
@@ -576,7 +577,7 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to writeConcernError ShutdownInProgress
+  - description: add RetryableWriteError and UnknownTransactionCommitResult labels to writeConcernError ShutdownInProgress
 
     failPoint:
       configureFailPoint: failCommand
@@ -586,6 +587,7 @@ tests:
           writeConcernError:
             code: 91
             errmsg: Replication is being shut down
+            errorLabels: ["RetryableWriteError"]
 
     operations:
       - name: startTransaction
@@ -605,7 +607,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       - name: commitTransaction
         object: session0
@@ -668,7 +670,7 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to writeConcernError WriteConcernFailed
+  - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed
 
     failPoint:
       configureFailPoint: failCommand
@@ -698,7 +700,7 @@ tests:
         object: session0
         result:
           errorLabelsContain: ["UnknownTransactionCommitResult"]
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
       - name: commitTransaction
         object: session0
 
@@ -748,7 +750,7 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to writeConcernError WriteConcernFailed with wtimeout
+  - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed with wtimeout
 
     failPoint:
       configureFailPoint: failCommand
@@ -780,7 +782,7 @@ tests:
         object: session0
         result:
           errorLabelsContain: ["UnknownTransactionCommitResult"]
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
       - name: commitTransaction
         object: session0
 
@@ -830,7 +832,7 @@ tests:
         data:
           - _id: 1
 
-  - description: omit unknown commit label to writeConcernError UnsatisfiableWriteConcern
+  - description: omit UnknownTransactionCommitResult label from writeConcernError UnsatisfiableWriteConcern
 
     failPoint:
       configureFailPoint: failCommand
@@ -859,7 +861,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -895,7 +897,7 @@ tests:
         data:
           - _id: 1
 
-  - description: omit unknown commit label to writeConcernError UnknownReplWriteConcern
+  - description: omit UnknownTransactionCommitResult label from writeConcernError UnknownReplWriteConcern
 
     failPoint:
       configureFailPoint: failCommand
@@ -924,7 +926,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteConcern", "TransientTransactionError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -960,7 +962,7 @@ tests:
         data:
           - _id: 1
 
-  - description: do not add unknown commit label to MaxTimeMSExpired inside transactions
+  - description: do not add UnknownTransactionCommitResult label to MaxTimeMSExpired inside transactions
 
     failPoint:
       configureFailPoint: failCommand
@@ -989,7 +991,7 @@ tests:
           maxTimeMS: 60000
           session: session0
         result:
-          errorLabelsOmit: ["UnknownTransactionCommitResult", "TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult", "TransientTransactionError"]
       - name: abortTransaction
         object: session0
 
@@ -1040,7 +1042,7 @@ tests:
       collection:
         data: []
 
-  - description: add unknown commit label to MaxTimeMSExpired
+  - description: add UnknownTransactionCommitResult label to MaxTimeMSExpired
 
     failPoint:
       configureFailPoint: failCommand
@@ -1069,7 +1071,7 @@ tests:
         object: session0
         result:
           errorLabelsContain: ["UnknownTransactionCommitResult"]
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
       - name: commitTransaction
         object: session0
 
@@ -1121,7 +1123,7 @@ tests:
         data:
           - _id: 1
 
-  - description: add unknown commit label to writeConcernError MaxTimeMSExpired
+  - description: add UnknownTransactionCommitResult label to writeConcernError MaxTimeMSExpired
 
     failPoint:
       configureFailPoint: failCommand
@@ -1152,7 +1154,7 @@ tests:
         object: session0
         result:
           errorLabelsContain: ["UnknownTransactionCommitResult"]
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
       - name: commitTransaction
         object: session0
 

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/mongos-recovery-token.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/mongos-recovery-token.json
@@ -181,7 +181,10 @@
                 ],
                 "writeConcernError": {
                   "code": 91,
-                  "errmsg": "Replication is being shut down"
+                  "errmsg": "Replication is being shut down",
+                  "errorLabels": [
+                    "RetryableWriteError"
+                  ]
                 }
               }
             }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/mongos-recovery-token.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/mongos-recovery-token.yml
@@ -119,6 +119,7 @@ tests:
               writeConcernError:
                 code: 91
                 errmsg: Replication is being shut down
+                errorLabels: ["RetryableWriteError"] # SPEC-1565
       # The client sees a retryable writeConcernError on the first
       # commitTransaction due to the fail point but it actually succeeds on the
       # server (SERVER-39346). The retry will succeed both on a new mongos and

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-abort-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-abort-errorLabels.json
@@ -1,0 +1,204 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "abortTransaction only retries once with RetryableWriteError from server",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "abortTransaction"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "abortTransaction does not retry without RetryableWriteError label",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "abortTransaction"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-abort-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-abort-errorLabels.yml
@@ -1,0 +1,124 @@
+runOn:
+    -
+        minServerVersion: "4.3.1"
+        topology: ["replicaset", "sharded"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+tests:
+  - description: abortTransaction only retries once with RetryableWriteError from server
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["abortTransaction"]
+          errorCode: 112 # WriteConflict, not a retryable error code
+          errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: abortTransaction
+        object: session0
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+      - command_started_event: # Driver retries abort once
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data: []
+
+  - description: abortTransaction does not retry without RetryableWriteError label
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["abortTransaction"]
+          errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+          errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: abortTransaction
+        object: session0
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+    outcome: # Driver does not retry abort
+      collection:
+          data: []

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-abort.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-abort.json
@@ -413,6 +413,9 @@
             "abortTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -514,6 +517,9 @@
             "abortTransaction"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -615,6 +621,9 @@
             "abortTransaction"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -705,7 +714,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after InterruptedDueToStepDown",
+      "description": "abortTransaction succeeds after InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -716,6 +725,9 @@
             "abortTransaction"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -817,6 +829,9 @@
             "abortTransaction"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -918,6 +933,9 @@
             "abortTransaction"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1019,6 +1037,9 @@
             "abortTransaction"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1120,6 +1141,9 @@
             "abortTransaction"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1221,6 +1245,9 @@
             "abortTransaction"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1322,6 +1349,9 @@
             "abortTransaction"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1423,6 +1453,9 @@
             "abortTransaction"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1525,6 +1558,9 @@
           ],
           "writeConcernError": {
             "code": 11600,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1627,7 +1663,7 @@
       }
     },
     {
-      "description": "abortTransaction succeeds after WriteConcernError InterruptedDueToStepDown",
+      "description": "abortTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1639,6 +1675,9 @@
           ],
           "writeConcernError": {
             "code": 11602,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1753,6 +1792,9 @@
           ],
           "writeConcernError": {
             "code": 189,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1867,6 +1909,9 @@
           ],
           "writeConcernError": {
             "code": 91,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-abort.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-abort.yml
@@ -274,6 +274,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 10107
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -341,6 +342,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 13436
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -408,6 +410,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 13435
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -467,7 +470,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after InterruptedDueToStepDown 
+  - description: abortTransaction succeeds after InterruptedDueToReplStateChange 
 
     failPoint:
       configureFailPoint: failCommand
@@ -475,6 +478,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 11602
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -542,6 +546,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 11600
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -609,6 +614,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 189
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -676,6 +682,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 91
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -743,6 +750,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 7
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -810,6 +818,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 6
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -877,6 +886,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 9001
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -944,6 +954,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 89
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -1012,6 +1023,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 11600
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1077,7 +1089,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after WriteConcernError InterruptedDueToStepDown 
+  - description: abortTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange 
 
     failPoint:
       configureFailPoint: failCommand
@@ -1086,6 +1098,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 11602
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1160,6 +1173,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 189
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1234,6 +1248,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 91
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-commit-errorLabels.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-commit-errorLabels.json
@@ -1,0 +1,223 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "commitTransaction does not retry error without RetryableWriteError label",
+      "clientOptions": {
+        "retryWrites": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 11600,
+          "errorLabels": []
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsOmit": [
+              "RetryableWriteError",
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "commitTransaction retries once with RetryableWriteError from server",
+      "clientOptions": {
+        "retryWrites": false
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 112,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-commit-errorLabels.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-commit-errorLabels.yml
@@ -1,0 +1,132 @@
+runOn:
+    -
+        minServerVersion: "4.3.1"
+        topology: ["replicaset", "sharded"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  - description: commitTransaction does not retry error without RetryableWriteError label
+    clientOptions:
+      retryWrites: false
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+          errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+        result:
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError"]
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+    outcome: # Driver does not retry commit because there was no RetryableWriteError label on response
+      collection:
+        data: []
+
+  - description: commitTransaction retries once with RetryableWriteError from server
+    clientOptions:
+      retryWrites: false
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 112 # WriteConflict, not a retryable error code
+          errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern: { w: majority, wtimeout: 10000 }
+          command_name: commitTransaction
+          database_name: admin
+    outcome: # Driver retries commit and it succeeds
+      collection:
+        data:
+          - _id: 1

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-commit.json
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-commit.json
@@ -57,6 +57,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -207,6 +208,7 @@
           "object": "session0",
           "result": {
             "errorLabelsContain": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ],
             "errorLabelsOmit": [
@@ -353,7 +355,9 @@
           "result": {
             "errorCodeName": "Interrupted",
             "errorLabelsOmit": [
-              "TransientTransactionError"
+              "RetryableWriteError",
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
             ]
           }
         }
@@ -406,7 +410,7 @@
       }
     },
     {
-      "description": "commitTransaction fails after WriteConcernError Interrupted",
+      "description": "commitTransaction is not retried after UnsatisfiableWriteConcern error",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -417,8 +421,8 @@
             "commitTransaction"
           ],
           "writeConcernError": {
-            "code": 11601,
-            "errmsg": "operation was interrupted"
+            "code": 100,
+            "errmsg": "Not enough data-bearing nodes"
           }
         }
       },
@@ -452,7 +456,9 @@
           "object": "session0",
           "result": {
             "errorLabelsOmit": [
-              "TransientTransactionError"
+              "RetryableWriteError",
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
             ]
           }
         }
@@ -629,6 +635,9 @@
             "commitTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -737,6 +746,9 @@
             "commitTransaction"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -845,6 +857,9 @@
             "commitTransaction"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -942,7 +957,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after InterruptedDueToStepDown",
+      "description": "commitTransaction succeeds after InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -953,6 +968,9 @@
             "commitTransaction"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1061,6 +1079,9 @@
             "commitTransaction"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1169,6 +1190,9 @@
             "commitTransaction"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1277,6 +1301,9 @@
             "commitTransaction"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1385,6 +1412,9 @@
             "commitTransaction"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1493,6 +1523,9 @@
             "commitTransaction"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1601,6 +1634,9 @@
             "commitTransaction"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1709,6 +1745,9 @@
             "commitTransaction"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1818,6 +1857,9 @@
           ],
           "writeConcernError": {
             "code": 11600,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1925,7 +1967,7 @@
       }
     },
     {
-      "description": "commitTransaction succeeds after WriteConcernError InterruptedDueToStepDown",
+      "description": "commitTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1937,6 +1979,9 @@
           ],
           "writeConcernError": {
             "code": 11602,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2056,6 +2101,9 @@
           ],
           "writeConcernError": {
             "code": 189,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2175,6 +2223,9 @@
           ],
           "writeConcernError": {
             "code": 91,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-commit.yml
+++ b/tests/MongoDB.Driver.Tests/Specifications/transactions/tests/retryable-commit.yml
@@ -39,7 +39,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       # Second call to commit succeeds because the failpoint was disabled.
       - name: commitTransaction
@@ -131,7 +131,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsContain: ["RetryableWriteError", "UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
       # Second call to commit succeeds because the failpoint was disabled.
       - name: commitTransaction
@@ -218,7 +218,7 @@ tests:
         object: session0
         result:
           errorCodeName: Interrupted
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -252,7 +252,7 @@ tests:
       collection:
         data: []
 
-  - description: commitTransaction fails after WriteConcernError Interrupted
+  - description: commitTransaction is not retried after UnsatisfiableWriteConcern error
 
     failPoint:
       configureFailPoint: failCommand
@@ -260,8 +260,8 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           writeConcernError:
-            code: 11601
-            errmsg: operation was interrupted
+            code: 100
+            errmsg: Not enough data-bearing nodes
 
     operations:
       - name: startTransaction
@@ -281,7 +281,7 @@ tests:
       - name: commitTransaction
         object: session0
         result:
-          errorLabelsOmit: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError", "UnknownTransactionCommitResult"]
 
     expectations:
       - command_started_event:
@@ -393,6 +393,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 10107
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -462,6 +463,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 13436
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -531,6 +533,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 13435
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -592,7 +595,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after InterruptedDueToStepDown 
+  - description: commitTransaction succeeds after InterruptedDueToReplStateChange
 
     failPoint:
       configureFailPoint: failCommand
@@ -600,6 +603,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11602
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -669,6 +673,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11600
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -738,6 +743,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 189
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -807,6 +813,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 91
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -876,6 +883,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 7
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -945,6 +953,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 6
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -1014,6 +1023,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 9001
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -1083,6 +1093,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 89
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -1153,6 +1164,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 11600
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1219,7 +1231,7 @@ tests:
         data:
           - _id: 1
 
-  - description: commitTransaction succeeds after WriteConcernError InterruptedDueToStepDown 
+  - description: commitTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange
 
     failPoint:
       configureFailPoint: failCommand
@@ -1228,6 +1240,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 11602
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1303,6 +1316,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 189
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1378,6 +1392,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 91
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e5427387742ae23d16c4449

