### PR TITLE
CSHARP-2732: Bump wire protocol version for 4.4.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/Cluster.cs
@@ -40,7 +40,7 @@ namespace MongoDB.Driver.Core.Clusters
         private static readonly TimeSpan __minHeartbeatInterval = TimeSpan.FromMilliseconds(500);
         private static readonly SemanticVersion __minSupportedServerVersion = new SemanticVersion(2, 6, 0);
         private static readonly IServerSelector __randomServerSelector = new RandomServerSelector();
-        private static readonly Range<int> __supportedWireVersionRange = new Range<int>(2, 8);
+        private static readonly Range<int> __supportedWireVersionRange = new Range<int>(2, 9);
 
         // static properties
         /// <summary>

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/ClusterTests.cs
@@ -60,7 +60,7 @@ namespace MongoDB.Driver.Core.Clusters
         {
             var result = Cluster.SupportedWireVersionRange;
 
-            result.Should().Be(new Range<int>(2, 8));
+            result.Should().Be(new Range<int>(2, 9));
         }
 
         [Fact]


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e5835621e2d175521cc9169