### PR TITLE
CSHARP-2738: Deprecate mapparams, out.sharded, and out.nonAtomic arguments to mapReduce.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Operations/MapReduceOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/MapReduceOperationBase.cs
@@ -14,9 +14,6 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver.Core.Bindings;
 using MongoDB.Driver.Core.Connections;
@@ -120,6 +117,7 @@ namespace MongoDB.Driver.Core.Operations
         /// </remarks>
         ///   <c>true</c> if objects emitted by the map function remain as JavaScript objects; otherwise, <c>false</c>.
         /// </value>
+        [Obsolete("JavaScriptMode is ignored by server versions 4.3.1 and newer.")]
         public bool? JavaScriptMode
         {
             get { return _javaScriptMode; }

--- a/src/MongoDB.Driver.Core/Core/Operations/MapReduceOperationBase.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/MapReduceOperationBase.cs
@@ -117,7 +117,7 @@ namespace MongoDB.Driver.Core.Operations
         /// </remarks>
         ///   <c>true</c> if objects emitted by the map function remain as JavaScript objects; otherwise, <c>false</c>.
         /// </value>
-        [Obsolete("JavaScriptMode is ignored by server versions 4.3.1 and newer.")]
+        [Obsolete("JavaScriptMode is ignored by server versions 4.4.0 and newer.")]
         public bool? JavaScriptMode
         {
             get { return _javaScriptMode; }

--- a/src/MongoDB.Driver.Core/Core/Operations/MapReduceOutputToCollectionOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/MapReduceOutputToCollectionOperation.cs
@@ -82,7 +82,7 @@ namespace MongoDB.Driver.Core.Operations
         /// <value>
         ///   <c>true</c> if the server should not lock the database for merge and reduce output modes; otherwise, <c>false</c>.
         /// </value>
-        [Obsolete("NonAtomicOutput is rejected by server versions 4.3.1 and newer.")]
+        [Obsolete("NonAtomicOutput is rejected by server versions 4.4.0 and newer.")]
         public bool? NonAtomicOutput
         {
             get { return _nonAtomicOutput; }
@@ -118,7 +118,7 @@ namespace MongoDB.Driver.Core.Operations
         /// <value>
         ///   <c>true</c> if the output collection should be sharded; otherwise, <c>false</c>.
         /// </value>
-        [Obsolete("ShardedOutput is rejected by server versions 4.3.1 and newer.")]
+        [Obsolete("ShardedOutput is rejected by server versions 4.4.0 and newer.")]
         public bool? ShardedOutput
         {
             get { return _shardedOutput; }

--- a/src/MongoDB.Driver.Core/Core/Operations/MapReduceOutputToCollectionOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/MapReduceOutputToCollectionOperation.cs
@@ -82,6 +82,7 @@ namespace MongoDB.Driver.Core.Operations
         /// <value>
         ///   <c>true</c> if the server should not lock the database for merge and reduce output modes; otherwise, <c>false</c>.
         /// </value>
+        [Obsolete("NonAtomicOutput is rejected by server versions 4.3.1 and newer.")]
         public bool? NonAtomicOutput
         {
             get { return _nonAtomicOutput; }
@@ -117,6 +118,7 @@ namespace MongoDB.Driver.Core.Operations
         /// <value>
         ///   <c>true</c> if the output collection should be sharded; otherwise, <c>false</c>.
         /// </value>
+        [Obsolete("ShardedOutput is rejected by server versions 4.3.1 and newer.")]
         public bool? ShardedOutput
         {
             get { return _shardedOutput; }

--- a/src/MongoDB.Driver.Legacy/CommandResults/MapReduceResult.cs
+++ b/src/MongoDB.Driver.Legacy/CommandResults/MapReduceResult.cs
@@ -84,7 +84,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the duration.
         /// </summary>
-        [Obsolete("Duration is not available on server versions 4.3.1 and newer.")]
+        [Obsolete("Duration is not available on server versions 4.4.0 and newer.")]
         public TimeSpan Duration
         {
             get { return TimeSpan.FromMilliseconds(Response["timeMillis"].ToInt32()); }
@@ -93,7 +93,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the emit count.
         /// </summary>
-        [Obsolete("EmitCount is not available on server versions 4.3.1 and newer.")]
+        [Obsolete("EmitCount is not available on server versions 4.4.0 and newer.")]
         public long EmitCount
         {
             get { return Response["counts"]["emit"].ToInt64(); }
@@ -102,7 +102,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the output count.
         /// </summary>
-        [Obsolete("OutputCount is not available on server versions 4.3.1 and newer.")]
+        [Obsolete("OutputCount is not available on server versions 4.4.0 and newer.")]
         public long OutputCount
         {
             get { return Response["counts"]["output"].ToInt64(); }
@@ -119,7 +119,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the input count.
         /// </summary>
-        [Obsolete("InputCount is not available on server versions 4.3.1 and newer.")]
+        [Obsolete("InputCount is not available on server versions 4.4.0 and newer.")]
         public long InputCount
         {
             get { return Response["counts"]["input"].ToInt64(); }

--- a/src/MongoDB.Driver.Legacy/CommandResults/MapReduceResult.cs
+++ b/src/MongoDB.Driver.Legacy/CommandResults/MapReduceResult.cs
@@ -84,6 +84,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the duration.
         /// </summary>
+        [Obsolete("Duration is ignored by server versions 4.3.1 and newer.")]
         public TimeSpan Duration
         {
             get { return TimeSpan.FromMilliseconds(Response["timeMillis"].ToInt32()); }
@@ -92,6 +93,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the emit count.
         /// </summary>
+        [Obsolete("EmitCount is ignored by server versions 4.3.1 and newer.")]
         public long EmitCount
         {
             get { return Response["counts"]["emit"].ToInt64(); }
@@ -100,6 +102,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the output count.
         /// </summary>
+        [Obsolete("OutputCount is ignored by server versions 4.3.1 and newer.")]
         public long OutputCount
         {
             get { return Response["counts"]["output"].ToInt64(); }
@@ -116,6 +119,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the input count.
         /// </summary>
+        [Obsolete("InputCount is ignored by server versions 4.3.1 and newer.")]
         public long InputCount
         {
             get { return Response["counts"]["input"].ToInt64(); }

--- a/src/MongoDB.Driver.Legacy/CommandResults/MapReduceResult.cs
+++ b/src/MongoDB.Driver.Legacy/CommandResults/MapReduceResult.cs
@@ -84,7 +84,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the duration.
         /// </summary>
-        [Obsolete("Duration is ignored by server versions 4.3.1 and newer.")]
+        [Obsolete("Duration is not available on server versions 4.3.1 and newer.")]
         public TimeSpan Duration
         {
             get { return TimeSpan.FromMilliseconds(Response["timeMillis"].ToInt32()); }
@@ -93,7 +93,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the emit count.
         /// </summary>
-        [Obsolete("EmitCount is ignored by server versions 4.3.1 and newer.")]
+        [Obsolete("EmitCount is not available on server versions 4.3.1 and newer.")]
         public long EmitCount
         {
             get { return Response["counts"]["emit"].ToInt64(); }
@@ -102,7 +102,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the output count.
         /// </summary>
-        [Obsolete("OutputCount is ignored by server versions 4.3.1 and newer.")]
+        [Obsolete("OutputCount is not available on server versions 4.3.1 and newer.")]
         public long OutputCount
         {
             get { return Response["counts"]["output"].ToInt64(); }
@@ -119,7 +119,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets the input count.
         /// </summary>
-        [Obsolete("InputCount is ignored by server versions 4.3.1 and newer.")]
+        [Obsolete("InputCount is not available on server versions 4.3.1 and newer.")]
         public long InputCount
         {
             get { return Response["counts"]["input"].ToInt64(); }

--- a/src/MongoDB.Driver.Legacy/MapReduceArgs.cs
+++ b/src/MongoDB.Driver.Legacy/MapReduceArgs.cs
@@ -122,7 +122,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the JavaScript mode (if true all intermediate values are kept in memory as JavaScript objects).
         /// </summary>
-        [Obsolete("JsMode is ignored by server versions 4.3.1 and newer.")]
+        [Obsolete("JsMode is ignored by server versions 4.4.0 and newer.")]
         public bool? JsMode
         {
             get { return _jsMode; }
@@ -177,7 +177,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets a value indicating whether Merge and Reduce output should not be atomic.
         /// </summary>
-        [Obsolete("OutputIsNonAtomic is rejected by server versions 4.3.1 and newer.")]
+        [Obsolete("OutputIsNonAtomic is rejected by server versions 4.4.0 and newer.")]
         public bool? OutputIsNonAtomic
         {
             get { return _outputIsNonAtomic; }
@@ -187,7 +187,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets a value indicating whether the output is sharded.
         /// </summary>
-        [Obsolete("OutputIsSharded is rejected by server versions 4.3.1 and newer.")]
+        [Obsolete("OutputIsSharded is rejected by server versions 4.4.0 and newer.")]
         public bool? OutputIsSharded
         {
             get { return _outputIsSharded; }

--- a/src/MongoDB.Driver.Legacy/MapReduceArgs.cs
+++ b/src/MongoDB.Driver.Legacy/MapReduceArgs.cs
@@ -122,6 +122,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the JavaScript mode (if true all intermediate values are kept in memory as JavaScript objects).
         /// </summary>
+        [Obsolete("JsMode is ignored by server versions 4.3.1 and newer.")]
         public bool? JsMode
         {
             get { return _jsMode; }
@@ -176,6 +177,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets a value indicating whether Merge and Reduce output should not be atomic.
         /// </summary>
+        [Obsolete("OutputIsNonAtomic is rejected by server versions 4.3.1 and newer.")]
         public bool? OutputIsNonAtomic
         {
             get { return _outputIsNonAtomic; }
@@ -185,6 +187,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets a value indicating whether the output is sharded.
         /// </summary>
+        [Obsolete("OutputIsSharded is rejected by server versions 4.3.1 and newer.")]
         public bool? OutputIsSharded
         {
             get { return _outputIsSharded; }

--- a/src/MongoDB.Driver.Legacy/MongoCollection.cs
+++ b/src/MongoDB.Driver.Legacy/MongoCollection.cs
@@ -1686,7 +1686,9 @@ namespace MongoDB.Driver
                     Collation = args.Collation,
                     Filter = query,
                     FinalizeFunction = args.FinalizeFunction,
+#pragma warning disable 618
                     JavaScriptMode = args.JsMode,
+#pragma warning restore 618
                     Limit = args.Limit,
                     MaxTime = args.MaxTime,
                     ReadConcern = _settings.ReadConcern,
@@ -1714,13 +1716,19 @@ namespace MongoDB.Driver
                     Collation = args.Collation,
                     Filter = query,
                     FinalizeFunction = args.FinalizeFunction,
+#pragma warning disable 618
                     JavaScriptMode = args.JsMode,
+#pragma warning restore 618
                     Limit = args.Limit,
                     MaxTime = args.MaxTime,
+#pragma warning disable 618
                     NonAtomicOutput = args.OutputIsNonAtomic,
+#pragma warning restore 618
                     OutputMode = outputMode,
                     Scope = scope,
+#pragma warning disable 618
                     ShardedOutput = args.OutputIsSharded,
+#pragma warning restore 618
                     Sort = sort,
                     Verbose = args.Verbose,
                     WriteConcern = _settings.WriteConcern

--- a/src/MongoDB.Driver/MapReduceOptions.cs
+++ b/src/MongoDB.Driver/MapReduceOptions.cs
@@ -81,6 +81,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the java script mode.
         /// </summary>
+        [Obsolete("JavaScriptMode is ignored by server versions 4.3.1 and newer.")]
         public bool? JavaScriptMode
         {
             get { return _javaScriptMode; }
@@ -177,10 +178,23 @@ namespace MongoDB.Driver
         /// <param name="sharded">Whether the output collection should be sharded.</param>
         /// <param name="nonAtomic">Whether the server should not lock the database for the duration of the merge.</param>
         /// <returns>A merge map-reduce output options.</returns>
+        [Obsolete("Use a Merge that does not have sharded and nonAtomic parameters instead.")]
         public static MapReduceOutputOptions Merge(string collectionName, string databaseName = null, bool? sharded = null, bool? nonAtomic = null)
         {
             Ensure.IsNotNull(collectionName, nameof(collectionName));
             return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Merge, databaseName, sharded, nonAtomic);
+        }
+
+        /// <summary>
+        /// A merge map-reduce output options.
+        /// </summary>
+        /// <param name="collectionName">The name of the collection.</param>
+        /// <param name="databaseName">The name of the database.</param>
+        /// <returns>A merge map-reduce output options.</returns>
+        public static MapReduceOutputOptions Merge(string collectionName, string databaseName = null)
+        {
+            Ensure.IsNotNull(collectionName, nameof(collectionName));
+            return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Merge, databaseName, sharded: null, nonAtomic: null);
         }
 
         /// <summary>
@@ -191,10 +205,23 @@ namespace MongoDB.Driver
         /// <param name="sharded">Whether the output collection should be sharded.</param>
         /// <param name="nonAtomic">Whether the server should not lock the database for the duration of the reduce.</param>
         /// <returns>A reduce map-reduce output options.</returns>
+        [Obsolete("Use a Reduce that does not have sharded and nonAtomic parameters instead.")]
         public static MapReduceOutputOptions Reduce(string collectionName, string databaseName = null, bool? sharded = null, bool? nonAtomic = null)
         {
             Ensure.IsNotNull(collectionName, nameof(collectionName));
             return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Reduce, databaseName, sharded, nonAtomic);
+        }
+
+        /// <summary>
+        /// A reduce map-reduce output options.
+        /// </summary>
+        /// <param name="collectionName">The name of the collection.</param>
+        /// <param name="databaseName">The name of the database.</param>
+        /// <returns>A reduce map-reduce output options.</returns>
+        public static MapReduceOutputOptions Reduce(string collectionName, string databaseName = null)
+        {
+            Ensure.IsNotNull(collectionName, nameof(collectionName));
+            return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Reduce, databaseName, sharded: null, nonAtomic: null); ; ;
         }
 
         /// <summary>
@@ -204,10 +231,23 @@ namespace MongoDB.Driver
         /// <param name="databaseName">Name of the database.</param>
         /// <param name="sharded">Whether the output collection should be sharded.</param>
         /// <returns>A replace map-reduce output options.</returns>
+        [Obsolete("Use a Replace that does not have a sharded parameter instead.")]
         public static MapReduceOutputOptions Replace(string collectionName, string databaseName = null, bool? sharded = null)
         {
             Ensure.IsNotNull(collectionName, nameof(collectionName));
             return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Replace, databaseName, sharded, null);
+        }
+
+        /// <summary>
+        /// A replace map-reduce output options.
+        /// </summary>
+        /// <param name="collectionName">The name of the collection.</param>
+        /// <param name="databaseName">Name of the database.</param>
+        /// <returns>A replace map-reduce output options.</returns>
+        public static MapReduceOutputOptions Replace(string collectionName, string databaseName = null)
+        {
+            Ensure.IsNotNull(collectionName, nameof(collectionName));
+            return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Replace, databaseName, sharded: null, null);
         }
 
         internal sealed class InlineOutput : MapReduceOutputOptions
@@ -243,6 +283,7 @@ namespace MongoDB.Driver
                 get { return _databaseName; }
             }
 
+            [Obsolete("NonAtomic is rejected by server versions 4.3.1 and newer.")]
             public bool? NonAtomic
             {
                 get { return _nonAtomic; }
@@ -253,6 +294,7 @@ namespace MongoDB.Driver
                 get { return _outputMode; }
             }
 
+            [Obsolete("Sharded is rejected by server versions 4.3.1 and newer.")]
             public bool? Sharded
             {
                 get { return _sharded; }

--- a/src/MongoDB.Driver/MapReduceOptions.cs
+++ b/src/MongoDB.Driver/MapReduceOptions.cs
@@ -81,7 +81,7 @@ namespace MongoDB.Driver
         /// <summary>
         /// Gets or sets the java script mode.
         /// </summary>
-        [Obsolete("JavaScriptMode is ignored by server versions 4.3.1 and newer.")]
+        [Obsolete("JavaScriptMode is ignored by server versions 4.4.0 and newer.")]
         public bool? JavaScriptMode
         {
             get { return _javaScriptMode; }
@@ -283,7 +283,7 @@ namespace MongoDB.Driver
                 get { return _databaseName; }
             }
 
-            [Obsolete("NonAtomic is rejected by server versions 4.3.1 and newer.")]
+            [Obsolete("NonAtomic is rejected by server versions 4.4.0 and newer.")]
             public bool? NonAtomic
             {
                 get { return _nonAtomic; }
@@ -294,7 +294,7 @@ namespace MongoDB.Driver
                 get { return _outputMode; }
             }
 
-            [Obsolete("Sharded is rejected by server versions 4.3.1 and newer.")]
+            [Obsolete("Sharded is rejected by server versions 4.4.0 and newer.")]
             public bool? Sharded
             {
                 get { return _sharded; }

--- a/src/MongoDB.Driver/MapReduceOptions.cs
+++ b/src/MongoDB.Driver/MapReduceOptions.cs
@@ -178,7 +178,7 @@ namespace MongoDB.Driver
         /// <param name="sharded">Whether the output collection should be sharded.</param>
         /// <param name="nonAtomic">Whether the server should not lock the database for the duration of the merge.</param>
         /// <returns>A merge map-reduce output options.</returns>
-        [Obsolete("Use a Merge that does not have sharded and nonAtomic parameters instead.")]
+        [Obsolete("Use an overload of Merge that does not have sharded and nonAtomic parameters instead.")]
         public static MapReduceOutputOptions Merge(string collectionName, string databaseName = null, bool? sharded = null, bool? nonAtomic = null)
         {
             Ensure.IsNotNull(collectionName, nameof(collectionName));
@@ -191,10 +191,10 @@ namespace MongoDB.Driver
         /// <param name="collectionName">The name of the collection.</param>
         /// <param name="databaseName">The name of the database.</param>
         /// <returns>A merge map-reduce output options.</returns>
-        public static MapReduceOutputOptions Merge(string collectionName, string databaseName = null)
+        public static MapReduceOutputOptions Merge(string collectionName, string databaseName)
         {
             Ensure.IsNotNull(collectionName, nameof(collectionName));
-            return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Merge, databaseName, sharded: null, nonAtomic: null);
+            return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Merge, databaseName);
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace MongoDB.Driver
         /// <param name="sharded">Whether the output collection should be sharded.</param>
         /// <param name="nonAtomic">Whether the server should not lock the database for the duration of the reduce.</param>
         /// <returns>A reduce map-reduce output options.</returns>
-        [Obsolete("Use a Reduce that does not have sharded and nonAtomic parameters instead.")]
+        [Obsolete("Use an overload of Reduce that does not have sharded and nonAtomic parameters instead.")]
         public static MapReduceOutputOptions Reduce(string collectionName, string databaseName = null, bool? sharded = null, bool? nonAtomic = null)
         {
             Ensure.IsNotNull(collectionName, nameof(collectionName));
@@ -218,10 +218,10 @@ namespace MongoDB.Driver
         /// <param name="collectionName">The name of the collection.</param>
         /// <param name="databaseName">The name of the database.</param>
         /// <returns>A reduce map-reduce output options.</returns>
-        public static MapReduceOutputOptions Reduce(string collectionName, string databaseName = null)
+        public static MapReduceOutputOptions Reduce(string collectionName, string databaseName)
         {
             Ensure.IsNotNull(collectionName, nameof(collectionName));
-            return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Reduce, databaseName, sharded: null, nonAtomic: null); ; ;
+            return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Reduce, databaseName);
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace MongoDB.Driver
         /// <param name="databaseName">Name of the database.</param>
         /// <param name="sharded">Whether the output collection should be sharded.</param>
         /// <returns>A replace map-reduce output options.</returns>
-        [Obsolete("Use a Replace that does not have a sharded parameter instead.")]
+        [Obsolete("Use an overload of Replace that does not have a sharded parameter instead.")]
         public static MapReduceOutputOptions Replace(string collectionName, string databaseName = null, bool? sharded = null)
         {
             Ensure.IsNotNull(collectionName, nameof(collectionName));
@@ -244,10 +244,10 @@ namespace MongoDB.Driver
         /// <param name="collectionName">The name of the collection.</param>
         /// <param name="databaseName">Name of the database.</param>
         /// <returns>A replace map-reduce output options.</returns>
-        public static MapReduceOutputOptions Replace(string collectionName, string databaseName = null)
+        public static MapReduceOutputOptions Replace(string collectionName, string databaseName)
         {
             Ensure.IsNotNull(collectionName, nameof(collectionName));
-            return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Replace, databaseName, sharded: null, null);
+            return new CollectionOutput(collectionName, Core.Operations.MapReduceOutputMode.Replace, databaseName);
         }
 
         internal sealed class InlineOutput : MapReduceOutputOptions

--- a/src/MongoDB.Driver/MongoCollectionImpl.cs
+++ b/src/MongoDB.Driver/MongoCollectionImpl.cs
@@ -1002,7 +1002,9 @@ namespace MongoDB.Driver
                 Collation = options.Collation,
                 Filter = options.Filter == null ? null : options.Filter.Render(_documentSerializer, _settings.SerializerRegistry),
                 FinalizeFunction = options.Finalize,
+#pragma warning disable 618
                 JavaScriptMode = options.JavaScriptMode,
+#pragma warning restore 618
                 Limit = options.Limit,
                 MaxTime = options.MaxTime,
                 ReadConcern = _settings.ReadConcern,
@@ -1031,13 +1033,19 @@ namespace MongoDB.Driver
                 Collation = options.Collation,
                 Filter = options.Filter == null ? null : options.Filter.Render(_documentSerializer, _settings.SerializerRegistry),
                 FinalizeFunction = options.Finalize,
+#pragma warning disable 618
                 JavaScriptMode = options.JavaScriptMode,
+#pragma warning restore 618
                 Limit = options.Limit,
                 MaxTime = options.MaxTime,
+#pragma warning disable 618
                 NonAtomicOutput = collectionOutputOptions.NonAtomic,
+#pragma warning restore 618
                 Scope = options.Scope,
                 OutputMode = collectionOutputOptions.OutputMode,
+#pragma warning disable 618
                 ShardedOutput = collectionOutputOptions.Sharded,
+#pragma warning restore 618
                 Sort = options.Sort == null ? null : options.Sort.Render(_documentSerializer, _settings.SerializerRegistry),
                 Verbose = options.Verbose,
                 WriteConcern = _settings.WriteConcern

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceLegacyOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceLegacyOperationTests.cs
@@ -16,8 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -81,8 +79,9 @@ namespace MongoDB.Driver.Core.Operations
             };
 
             var result = ExecuteOperation(subject, async);
+            var results = result["results"].AsBsonArray.ToList();
 
-            result["results"].Should().Be(new BsonArray(expectedResults));
+            results.Should().BeEquivalentTo(new BsonArray(expectedResults));
         }
 
         [SkippableTheory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceOperationBaseTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceOperationBaseTests.cs
@@ -72,7 +72,9 @@ namespace MongoDB.Driver.Core.Operations
             subject.Collation.Should().BeNull();
             subject.Filter.Should().BeNull();
             subject.FinalizeFunction.Should().BeNull();
+#pragma warning disable 618
             subject.JavaScriptMode.Should().NotHaveValue();
+#pragma warning restore 618
             subject.Limit.Should().NotHaveValue();
             subject.MaxTime.Should().NotHaveValue();
             subject.Scope.Should().BeNull();
@@ -240,7 +242,9 @@ namespace MongoDB.Driver.Core.Operations
         {
             var subject = new FakeMapReduceOperation(_collectionNamespace, _mapFunction, _reduceFunction, _messageEncoderSettings)
             {
+#pragma warning disable 618
                 JavaScriptMode = javaScriptMode
+#pragma warning restore 618
             };
             var session = OperationTestHelper.CreateSession();
             var connectionDescription = OperationTestHelper.CreateConnectionDescription();
@@ -432,8 +436,10 @@ namespace MongoDB.Driver.Core.Operations
         {
             var subject = new FakeMapReduceOperation(_collectionNamespace, _mapFunction, _reduceFunction, _messageEncoderSettings);
 
+#pragma warning disable 618
             subject.JavaScriptMode = value;
             var result = subject.JavaScriptMode;
+#pragma warning restore 618
 
             result.Should().Be(value);
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceOperationTests.cs
@@ -42,10 +42,10 @@ namespace MongoDB.Driver.Core.Operations
             _mapFunction = "function() { emit(this.x, this.v); }";
             _reduceFunction = "function(key, values) { var sum = 0; for (var i = 0; i < values.length; i++) { sum += values[i]; }; return sum; }";
             _resultSerializer = BsonDocumentSerializer.Instance;
-    }
+        }
 
-    // test methods
-    [Fact]
+        // test methods
+        [Fact]
         public void constructor_should_initialize_instance()
         {
             var subject = new MapReduceOperation<BsonDocument>(_collectionNamespace, _mapFunction, _reduceFunction, _resultSerializer, _messageEncoderSettings);
@@ -59,7 +59,9 @@ namespace MongoDB.Driver.Core.Operations
             subject.Collation.Should().BeNull();
             subject.Filter.Should().BeNull();
             subject.FinalizeFunction.Should().BeNull();
+#pragma warning disable 618
             subject.JavaScriptMode.Should().NotHaveValue();
+#pragma warning restore 618
             subject.Limit.Should().NotHaveValue();
             subject.MaxTime.Should().NotHaveValue();
             subject.ReadConcern.Should().BeSameAs(ReadConcern.Default);
@@ -137,7 +139,7 @@ namespace MongoDB.Driver.Core.Operations
             var cursor = ExecuteOperation(subject, async);
             var results = ReadCursorToEnd(cursor, async);
 
-            results.Should().Equal(
+            results.Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : 3 }"),
                 BsonDocument.Parse("{ _id : 2, value : 4 }"));
         }
@@ -180,7 +182,7 @@ namespace MongoDB.Driver.Core.Operations
                     BsonDocument.Parse("{ _id : 2, value : 4 }")
                 };
             }
-            results.Should().Equal(expectedResults);
+            results.Should().BeEquivalentTo(expectedResults);
         }
 
         [SkippableTheory]
@@ -200,7 +202,7 @@ namespace MongoDB.Driver.Core.Operations
             var cursor = ExecuteOperation(subject, async);
             var results = ReadCursorToEnd(cursor, async);
 
-            results.Should().Equal(
+            results.Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : 1 }"),
                 BsonDocument.Parse("{ _id : 2, value : 4 }"));
         }
@@ -222,7 +224,7 @@ namespace MongoDB.Driver.Core.Operations
             var cursor = ExecuteOperation(subject, async);
             var results = ReadCursorToEnd(cursor, async);
 
-            results.Should().Equal(
+            results.Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : -3 }"),
                 BsonDocument.Parse("{ _id : 2, value : -4 }"));
         }
@@ -298,7 +300,7 @@ namespace MongoDB.Driver.Core.Operations
             var results = ReadCursorToEnd(cursor, async);
 
             // results should be the same whether MaxTime was used or not
-            results.Should().Equal(
+            results.Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : 3 }"),
                 BsonDocument.Parse("{ _id : 2, value : 4 }"));
         }
@@ -323,7 +325,7 @@ namespace MongoDB.Driver.Core.Operations
             var cursor = ExecuteOperation(subject, async);
             var results = ReadCursorToEnd(cursor, async);
 
-            results.Should().Equal(
+            results.Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : 3 }"),
                 BsonDocument.Parse("{ _id : 2, value : 4 }"));
         }
@@ -342,6 +344,7 @@ namespace MongoDB.Driver.Core.Operations
             var cursor = ExecuteOperation(subject, async);
             var results = ReadCursorToEnd(cursor, async);
 
+            results.Sort();
             results.Should().Equal(3, 4);
         }
 
@@ -364,7 +367,7 @@ namespace MongoDB.Driver.Core.Operations
             var cursor = ExecuteOperation(subject, async);
             var results = ReadCursorToEnd(cursor, async);
 
-            results.Should().Equal(
+            results.Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : 3 }"),
                 BsonDocument.Parse("{ _id : 2, value : 4 }"));
         }
@@ -405,7 +408,7 @@ namespace MongoDB.Driver.Core.Operations
                     BsonDocument.Parse("{ _id : 2, value : 4 }")
                 };
             }
-            results.Should().Equal(expectedResults);
+            results.Should().BeEquivalentTo(expectedResults);
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceOutputToCollectionOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/MapReduceOutputToCollectionOperationTests.cs
@@ -58,10 +58,14 @@ namespace MongoDB.Driver.Core.Operations
             subject.Collation.Should().BeNull();
             subject.Filter.Should().BeNull();
             subject.FinalizeFunction.Should().BeNull();
+#pragma warning disable 618
             subject.JavaScriptMode.Should().NotHaveValue();
+#pragma warning restore 618
             subject.Limit.Should().NotHaveValue();
             subject.MaxTime.Should().NotHaveValue();
+#pragma warning disable 618
             subject.NonAtomicOutput.Should().NotHaveValue();
+#pragma warning restore 618
             subject.OutputMode.Should().Be(MapReduceOutputMode.Replace);
             subject.Scope.Should().BeNull();
             subject.Sort.Should().BeNull();
@@ -114,8 +118,10 @@ namespace MongoDB.Driver.Core.Operations
         {
             var subject = new MapReduceOutputToCollectionOperation(_collectionNamespace, _outputCollectionNamespace, _mapFunction, _reduceFunction, _messageEncoderSettings);
 
+#pragma warning disable 618
             subject.NonAtomicOutput = value;
             var result = subject.NonAtomicOutput;
+#pragma warning restore 618
 
             result.Should().Be(value);
         }
@@ -156,8 +162,10 @@ namespace MongoDB.Driver.Core.Operations
         {
             var subject = new MapReduceOutputToCollectionOperation(_collectionNamespace, _outputCollectionNamespace, _mapFunction, _reduceFunction, _messageEncoderSettings);
 
+#pragma warning disable 618
             subject.ShardedOutput = value;
             var result = subject.ShardedOutput;
+#pragma warning restore 618
 
             result.Should().Be(value);
         }
@@ -264,7 +272,9 @@ namespace MongoDB.Driver.Core.Operations
         {
             var subject = new MapReduceOutputToCollectionOperation(_collectionNamespace, _outputCollectionNamespace, _mapFunction, _reduceFunction, _messageEncoderSettings)
             {
+#pragma warning disable 618
                 ShardedOutput = shardedOutput
+#pragma warning restore 618
             };
             var subjectReflector = new Reflector(subject);
 
@@ -287,7 +297,9 @@ namespace MongoDB.Driver.Core.Operations
         {
             var subject = new MapReduceOutputToCollectionOperation(_collectionNamespace, _outputCollectionNamespace, _mapFunction, _reduceFunction, _messageEncoderSettings)
             {
+#pragma warning disable 618
                 NonAtomicOutput = nonAtomicOutput
+#pragma warning restore 618
             };
             var subjectReflector = new Reflector(subject);
             var expectedResult = new BsonDocument
@@ -314,7 +326,7 @@ namespace MongoDB.Driver.Core.Operations
 
             ExecuteOperation(subject, async);
 
-            ReadAllFromCollection(_outputCollectionNamespace).Should().Equal(
+            ReadAllFromCollection(_outputCollectionNamespace).Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : 3 }"),
                 BsonDocument.Parse("{ _id : 2, value : 4 }"));
         }
@@ -356,7 +368,7 @@ namespace MongoDB.Driver.Core.Operations
                     BsonDocument.Parse("{ _id : 2, value : 4 }")
                 };
             }
-            ReadAllFromCollection(_outputCollectionNamespace).Should().Equal(expectedResults);
+            ReadAllFromCollection(_outputCollectionNamespace).Should().BeEquivalentTo(expectedResults);
         }
 
         [SkippableTheory]
@@ -375,7 +387,7 @@ namespace MongoDB.Driver.Core.Operations
 
             ExecuteOperation(subject, async);
 
-            ReadAllFromCollection(_outputCollectionNamespace).Should().Equal(
+            ReadAllFromCollection(_outputCollectionNamespace).Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : 1 }"),
                 BsonDocument.Parse("{ _id : 2, value : 4 }"));
         }
@@ -396,7 +408,7 @@ namespace MongoDB.Driver.Core.Operations
 
             ExecuteOperation(subject, async);
 
-            ReadAllFromCollection(_outputCollectionNamespace).Should().Equal(
+            ReadAllFromCollection(_outputCollectionNamespace).Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : -3 }"),
                 BsonDocument.Parse("{ _id : 2, value : -4 }"));
         }
@@ -469,7 +481,7 @@ namespace MongoDB.Driver.Core.Operations
             ExecuteOperation(subject, async);
 
             // results should be the same whether MaxTime was used or not
-            ReadAllFromCollection(_outputCollectionNamespace).Should().Equal(
+            ReadAllFromCollection(_outputCollectionNamespace).Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : 3 }"),
                 BsonDocument.Parse("{ _id : 2, value : 4 }"));
         }
@@ -492,7 +504,7 @@ namespace MongoDB.Driver.Core.Operations
 
             ExecuteOperation(subject, async);
 
-            ReadAllFromCollection(_outputCollectionNamespace).Should().Equal(
+            ReadAllFromCollection(_outputCollectionNamespace).Should().BeEquivalentTo(
                 BsonDocument.Parse("{ _id : 1, value : 3 }"),
                 BsonDocument.Parse("{ _id : 2, value : 4 }"));
         }
@@ -532,7 +544,7 @@ namespace MongoDB.Driver.Core.Operations
                     BsonDocument.Parse("{ _id : 2, value : 4 }")
                 };
             }
-            ReadAllFromCollection(_outputCollectionNamespace).Should().Equal(expectedResults);
+            ReadAllFromCollection(_outputCollectionNamespace).Should().BeEquivalentTo(expectedResults);
         }
 
         [Theory]

--- a/tests/MongoDB.Driver.Legacy.Tests/MongoCollectionTests.cs
+++ b/tests/MongoDB.Driver.Legacy.Tests/MongoCollectionTests.cs
@@ -37,6 +37,10 @@ namespace MongoDB.Driver.Tests
 {
     public class MongoCollectionTests
     {
+        #region static
+        private static readonly SemanticVersion __mapReduceNewServerImplementationServerVersion = new SemanticVersion(4, 3, 0);
+        #endregion
+
         private class TestClass
         {
             public ObjectId Id { get; set; }
@@ -2606,10 +2610,15 @@ namespace MongoDB.Driver.Tests
             });
 
             Assert.True(result.Ok);
-            Assert.True(result.Duration >= TimeSpan.Zero);
-            Assert.Equal(9, result.EmitCount);
-            Assert.Equal(5, result.OutputCount);
-            Assert.Equal(3, result.InputCount);
+            if (CoreTestConfiguration.ServerVersion < __mapReduceNewServerImplementationServerVersion)
+            {
+#pragma warning disable 618
+                Assert.True(result.Duration >= TimeSpan.Zero);
+                Assert.Equal(9, result.EmitCount);
+                Assert.Equal(5, result.OutputCount);
+                Assert.Equal(3, result.InputCount);
+#pragma warning restore 618
+            }
             result.CollectionName.Should().NotBeNullOrEmpty();
 
             var expectedCounts = new Dictionary<string, int>
@@ -2680,10 +2689,15 @@ namespace MongoDB.Driver.Tests
                 });
 
                 Assert.True(result.Ok);
-                Assert.True(result.Duration >= TimeSpan.Zero);
-                Assert.Equal(9, result.EmitCount);
-                Assert.Equal(5, result.OutputCount);
-                Assert.Equal(3, result.InputCount);
+                if (CoreTestConfiguration.ServerVersion < __mapReduceNewServerImplementationServerVersion)
+                {
+#pragma warning disable 618
+                    Assert.True(result.Duration >= TimeSpan.Zero);
+                    Assert.Equal(9, result.EmitCount);
+                    Assert.Equal(5, result.OutputCount);
+                    Assert.Equal(3, result.InputCount);
+#pragma warning restore 618
+                }
                 result.CollectionName.Should().BeNullOrEmpty();
 
                 var expectedCounts = new Dictionary<string, int>
@@ -2788,10 +2802,15 @@ namespace MongoDB.Driver.Tests
                 });
 
                 Assert.True(result.Ok);
-                Assert.True(result.Duration >= TimeSpan.Zero);
-                Assert.Equal(9, result.EmitCount);
-                Assert.Equal(5, result.OutputCount);
-                Assert.Equal(3, result.InputCount);
+                if (CoreTestConfiguration.ServerVersion < __mapReduceNewServerImplementationServerVersion)
+                {
+#pragma warning disable 618
+                    Assert.True(result.Duration >= TimeSpan.Zero);
+                    Assert.Equal(9, result.EmitCount);
+                    Assert.Equal(5, result.OutputCount);
+                    Assert.Equal(3, result.InputCount);
+#pragma warning restore 618
+                }
                 result.CollectionName.Should().BeNullOrEmpty();
 
                 var expectedCounts = new Dictionary<string, int>

--- a/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionImplTests.cs
@@ -2320,7 +2320,9 @@ namespace MongoDB.Driver
                 Collation = new Collation("en_US"),
                 Filter = filterDefinition,
                 Finalize = new BsonJavaScript("finalizer"),
+#pragma warning disable 618
                 JavaScriptMode = true,
+#pragma warning restore 618
                 Limit = 10,
                 MaxTime = TimeSpan.FromMinutes(2),
                 OutputOptions = MapReduceOutputOptions.Inline,
@@ -2361,7 +2363,9 @@ namespace MongoDB.Driver
             operation.CollectionNamespace.Should().Be(subject.CollectionNamespace);
             operation.Filter.Should().Be(filterDocument);
             operation.FinalizeFunction.Should().Be(options.Finalize);
+#pragma warning disable 618
             operation.JavaScriptMode.Should().Be(options.JavaScriptMode);
+#pragma warning restore 618
             operation.Limit.Should().Be(options.Limit);
             operation.MapFunction.Should().Be(map);
             operation.MaxTime.Should().Be(options.MaxTime);
@@ -2394,10 +2398,14 @@ namespace MongoDB.Driver
                 Collation = new Collation("en_US"),
                 Filter = filterDefinition,
                 Finalize = new BsonJavaScript("finalizer"),
+#pragma warning disable 618
                 JavaScriptMode = true,
+#pragma warning restore 618
                 Limit = 10,
                 MaxTime = TimeSpan.FromMinutes(2),
+#pragma warning disable 618
                 OutputOptions = MapReduceOutputOptions.Replace("awesome", "otherDB", true),
+#pragma warning restore 618
                 Scope = new BsonDocument("test", 3),
                 Sort = sortDefinition,
                 Verbose = true
@@ -2436,16 +2444,22 @@ namespace MongoDB.Driver
             operation.CollectionNamespace.Should().Be(subject.CollectionNamespace);
             operation.Filter.Should().Be(filterDocument);
             operation.FinalizeFunction.Should().Be(options.Finalize);
+#pragma warning disable 618
             operation.JavaScriptMode.Should().Be(options.JavaScriptMode);
+#pragma warning restore 618
             operation.Limit.Should().Be(options.Limit);
             operation.MapFunction.Should().Be(map);
             operation.MaxTime.Should().Be(options.MaxTime);
+#pragma warning disable 618
             operation.NonAtomicOutput.Should().NotHaveValue();
+#pragma warning restore 618
             operation.OutputCollectionNamespace.Should().Be(CollectionNamespace.FromFullName("otherDB.awesome"));
             operation.OutputMode.Should().Be(Core.Operations.MapReduceOutputMode.Replace);
             operation.ReduceFunction.Should().Be(reduce);
             operation.Scope.Should().Be(options.Scope);
+#pragma warning disable 618
             operation.ShardedOutput.Should().Be(true);
+#pragma warning restore 618
             operation.Sort.Should().Be(sortDocument);
             operation.Verbose.Should().Be(options.Verbose);
             operation.WriteConcern.Should().BeSameAs(writeConcern);


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e598369d1fe0752de8ccb14