### PR TITLE
CSHARP-2572: Support all new $meta projections.

### DIFF
--- a/src/MongoDB.Driver/ProjectionDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/ProjectionDefinitionBuilder.cs
@@ -140,6 +140,22 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Combines an existing projection with a meta projection.
+        /// </summary>
+        /// <typeparam name="TDocument">The type of the document.</typeparam>
+        /// <param name="projection">The projection.</param>
+        /// <param name="field">The field.</param>
+        /// <param name="metaFieldName">The meta field name.</param>
+        /// <returns>
+        /// A combined projection.
+        /// </returns>
+        public static ProjectionDefinition<TDocument> Meta<TDocument>(this ProjectionDefinition<TDocument> projection, string field, string metaFieldName)
+        {
+            var builder = Builders<TDocument>.Projection;
+            return builder.Combine(projection, builder.Meta(field, metaFieldName));
+        }
+
+        /// <summary>
         /// Combines an existing projection with a text score projection.
         /// </summary>
         /// <typeparam name="TDocument">The type of the document.</typeparam>
@@ -334,6 +350,19 @@ namespace MongoDB.Driver
         }
 
         /// <summary>
+        /// Creates a meta projection.
+        /// </summary>
+        /// <param name="field">The field.</param>
+        /// <param name="metaFieldName">The meta field name.</param>
+        /// <returns>
+        /// A text score projection.
+        /// </returns>
+        public ProjectionDefinition<TSource> Meta(string field, string metaFieldName)
+        {
+            return new SingleFieldProjectionDefinition<TSource>(field, new BsonDocument("$meta", metaFieldName));
+        }
+
+        /// <summary>
         /// Creates a text score projection.
         /// </summary>
         /// <param name="field">The field.</param>
@@ -342,7 +371,7 @@ namespace MongoDB.Driver
         /// </returns>
         public ProjectionDefinition<TSource> MetaTextScore(string field)
         {
-            return new SingleFieldProjectionDefinition<TSource>(field, new BsonDocument("$meta", "textScore"));
+            return Meta(field, "textScore");
         }
 
         /// <summary>

--- a/tests/MongoDB.Driver.Tests/ProjectionDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/ProjectionDefinitionBuilderTests.cs
@@ -128,6 +128,23 @@ namespace MongoDB.Driver.Tests
             Assert(subject.Include("FirstName"), "{fn: 1}");
         }
 
+        [Theory]
+        [InlineData("textScore")]
+        [InlineData("randVal")]
+        [InlineData("searchScore")]
+        [InlineData("searchHighlights")]
+        [InlineData("geoNearDistance")]
+        [InlineData("geoNearPoint")]
+        [InlineData("recordId")]
+        [InlineData("indexKey")]
+        [InlineData("sortKey")]
+        public void Meta(string metaFieldName)
+        {
+            var subject = CreateSubject<BsonDocument>();
+
+            Assert(subject.Meta("a", metaFieldName), $"{{ a : {{ $meta : '{metaFieldName}' }} }}");
+        }
+
         [Fact]
         public void MetaTextScore()
         {


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e5d1f792a60ed322aae086a

**NOTES**:
1. I took the java implementation as an example. In particular, I rely on the server exception in case if the provided meta field name is not supported.
2. The c# ticket title tells only about adding meta options for projections. But the driver doesn't have this restriction in the title. For this point, I also relied on the java implementation and added the required change only for the projection (and didn't touch [SortDefinition](https://github.com/mongodb/mongo-csharp-driver/blob/14e046f23640ff9257c4edf53065b9a6768254d4/src/MongoDB.Driver/SortDefinitionBuilder.cs#L102)).
3. I didn't touch legacy.