### PR TITLE
CSHARP-2958: Research possible places when we use string comparison in an unsafe way.

### DIFF
--- a/src/MongoDB.Bson/IO/BsonBinaryReader.cs
+++ b/src/MongoDB.Bson/IO/BsonBinaryReader.cs
@@ -219,7 +219,7 @@ namespace MongoDB.Bson.IO
             }
             catch (FormatException ex)
             {
-                if (ex.Message.StartsWith("Detected unknown BSON type"))
+                if (ex.Message.StartsWith("Detected unknown BSON type", StringComparison.Ordinal))
                 {
                     // insert the element name into the error message
                     var periodIndex = ex.Message.IndexOf('.');

--- a/src/MongoDB.Bson/Serialization/Conventions/ConventionBase.cs
+++ b/src/MongoDB.Bson/Serialization/Conventions/ConventionBase.cs
@@ -61,7 +61,7 @@ namespace MongoDB.Bson.Serialization.Conventions
         private static string GetName(Type type)
         {
             var name = type.Name;
-            if (name.EndsWith("Convention"))
+            if (name.EndsWith("Convention", StringComparison.Ordinal))
             {
                 return name.Substring(0, name.Length - 10);
             }

--- a/src/MongoDB.Driver.Core/Core/Authentication/ScramShaAuthenticator.cs
+++ b/src/MongoDB.Driver.Core/Core/Authentication/ScramShaAuthenticator.cs
@@ -125,7 +125,7 @@ namespace MongoDB.Driver.Core.Authentication
                 _h = h;
                 _hi = hi;
                 _hmac = hmac;
-                if (!hashAlgorithmName.ToString().StartsWith("SHA"))
+                if (!hashAlgorithmName.ToString().StartsWith("SHA", StringComparison.Ordinal))
                 {
                     throw new ArgumentException("Must specify a SHA algorithm.");
                 }

--- a/src/MongoDB.Driver.Core/Core/Clusters/DnsMonitor.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/DnsMonitor.cs
@@ -128,7 +128,7 @@ namespace MongoDB.Driver.Core.Clusters
             {
                 var endPoint = srvRecord.EndPoint;
                 var host = endPoint.Host;
-                if (host.EndsWith("."))
+                if (host.EndsWith(".", StringComparison.Ordinal))
                 {
                     host = host.Substring(0, host.Length - 1);
                     endPoint = new DnsEndPoint(host, endPoint.Port);

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -1174,7 +1174,7 @@ namespace MongoDB.Driver.Core.Configuration
             foreach (var srvRecord in response.Answers.SrvRecords())
             {
                 var h = srvRecord.Target.ToString();
-                if (h.EndsWith("."))
+                if (h.EndsWith(".", StringComparison.Ordinal))
                 {
                     h = h.Substring(0, h.Length - 1);
                 }

--- a/src/MongoDB.Driver.Core/Core/Connections/CommandEventHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/CommandEventHelper.cs
@@ -1038,7 +1038,7 @@ namespace MongoDB.Driver.Core.Connections
                             // explain is special and gets handled elsewhere
                             break;
                         default:
-                            if (element.Name.StartsWith("$"))
+                            if (element.Name.StartsWith("$", StringComparison.Ordinal))
                             {
                                 // should we actually remove the $ or not?
                                 command[element.Name.Substring(1)] = element.Value;

--- a/src/MongoDB.Driver.Core/Core/Operations/ListCollectionsUsingQueryOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/ListCollectionsUsingQueryOperation.cs
@@ -177,7 +177,7 @@ namespace MongoDB.Driver.Core.Operations
             foreach (var collection in collections)
             {
                 var name = (string)collection["name"];
-                if (name.StartsWith(prefix))
+                if (name.StartsWith(prefix, StringComparison.Ordinal))
                 {
                     var collectionName = name.Substring(prefix.Length);
                     if (!collectionName.Contains('$'))

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -371,7 +371,7 @@ namespace MongoDB.Driver.Core.WireProtocol
                 exception.Result.TryGetValue("code", out var errorCode) &&
                 errorCode.ToInt32() == 20 &&
                 exception.Result.TryGetValue("errmsg", out var errmsg) &&
-                errmsg.AsString.StartsWith("Transaction numbers");
+                errmsg.AsString.StartsWith("Transaction numbers", StringComparison.Ordinal);
         }
 
 

--- a/src/MongoDB.Driver.Legacy/Linq/Translators/PredicateTranslator.cs
+++ b/src/MongoDB.Driver.Legacy/Linq/Translators/PredicateTranslator.cs
@@ -1289,11 +1289,11 @@ namespace MongoDB.Driver.Linq
             }
 
             pattern = "^" + pattern + "$";
-            if (pattern.StartsWith("^.*"))
+            if (pattern.StartsWith("^.*", StringComparison.Ordinal))
             {
                 pattern = pattern.Substring(3);
             }
-            if (pattern.EndsWith(".*$"))
+            if (pattern.EndsWith(".*$", StringComparison.Ordinal))
             {
                 pattern = pattern.Substring(0, pattern.Length - 3);
             }

--- a/src/MongoDB.Driver.Legacy/MongoCollection.cs
+++ b/src/MongoDB.Driver.Legacy/MongoCollection.cs
@@ -665,7 +665,7 @@ namespace MongoDB.Driver
             var sort = args.SortBy == null ? null : new BsonDocumentWrapper(args.SortBy);
 
             FindAndModifyOperationBase<BsonDocument> operation;
-            if (updateDocument.ElementCount > 0 && updateDocument.GetElement(0).Name.StartsWith("$"))
+            if (updateDocument.ElementCount > 0 && updateDocument.GetElement(0).Name.StartsWith("$", StringComparison.Ordinal))
             {
                 operation = new FindOneAndUpdateOperation<BsonDocument>(_collectionNamespace, filter, updateDocument, resultSerializer, messageEncoderSettings)
                 {

--- a/src/MongoDB.Driver/FilterDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/FilterDefinitionBuilder.cs
@@ -1839,7 +1839,7 @@ namespace MongoDB.Driver
 
         private static BsonDocument NegateArbitraryFilter(BsonDocument filter)
         {
-            if (filter.ElementCount == 1 && filter.GetElement(0).Name.StartsWith("$"))
+            if (filter.ElementCount == 1 && filter.GetElement(0).Name.StartsWith("$", StringComparison.Ordinal))
             {
                 return new BsonDocument("$not", filter);
             }

--- a/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/OrderByBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/OrderByBinder.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -33,7 +34,7 @@ namespace MongoDB.Driver.Linq.Processors.Pipeline.MethodCallBinders
 
         public Expression Bind(PipelineExpression pipeline, PipelineBindingContext bindingContext, MethodCallExpression node, IEnumerable<Expression> arguments)
         {
-            var direction = node.Method.Name.EndsWith("Descending") ?
+            var direction = node.Method.Name.EndsWith("Descending", StringComparison.Ordinal) ?
                 SortDirection.Descending :
                 SortDirection.Ascending;
 

--- a/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/ThenByBinder.cs
+++ b/src/MongoDB.Driver/Linq/Processors/Pipeline/MethodCallBinders/ThenByBinder.cs
@@ -13,6 +13,7 @@
 * limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -33,7 +34,7 @@ namespace MongoDB.Driver.Linq.Processors.Pipeline.MethodCallBinders
 
         public Expression Bind(PipelineExpression pipeline, PipelineBindingContext bindingContext, MethodCallExpression node, IEnumerable<Expression> arguments)
         {
-            var direction = node.Method.Name.EndsWith("Descending") ?
+            var direction = node.Method.Name.EndsWith("Descending", StringComparison.Ordinal) ?
                 SortDirection.Descending :
                 SortDirection.Ascending;
 

--- a/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
@@ -242,7 +242,7 @@ namespace MongoDB.Driver.Linq.Translators
         {
             var value = BsonValue.Create(((ConstantExpression)node).Value);
             var stringValue = value as BsonString;
-            if (stringValue != null && stringValue.Value.StartsWith("$"))
+            if (stringValue != null && stringValue.Value.StartsWith("$", StringComparison.Ordinal))
             {
                 value = new BsonDocument("$literal", value);
             }

--- a/src/MongoDB.Driver/Linq/Translators/FindProjectionTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/FindProjectionTranslator.cs
@@ -219,7 +219,7 @@ namespace MongoDB.Driver.Linq.Translators
                 if (!skippedFields.Contains(referenceGroup.Key))
                 {
                     var prefix = referenceGroup.Key + '.';
-                    var hierarchicalReferenceGroups = referenceGroups.Where(x => x.Key.StartsWith(prefix));
+                    var hierarchicalReferenceGroups = referenceGroups.Where(x => x.Key.StartsWith(prefix, StringComparison.Ordinal));
                     uniqueFields.AddRange(referenceGroup);
                     skippedFields.AddRange(hierarchicalReferenceGroups.Select(x => x.Key));
                 }
@@ -261,7 +261,7 @@ namespace MongoDB.Driver.Linq.Translators
                 if (source != null)
                 {
                     var fields = Gather(node.Arguments[1]);
-                    if (fields.Any(x => x.FieldName.StartsWith(source.FieldName)))
+                    if (fields.Any(x => x.FieldName.StartsWith(source.FieldName, StringComparison.Ordinal)))
                     {
                         _fieldExpressions.AddRange(fields);
                         return node;
@@ -296,7 +296,7 @@ namespace MongoDB.Driver.Linq.Translators
 
                 var currentKey = (string)((ConstantExpression)node.Arguments[0]).Value;
 
-                if (!currentKey.StartsWith(_keyPrefix))
+                if (!currentKey.StartsWith(_keyPrefix, StringComparison.Ordinal))
                 {
                     return base.VisitMethodCall(node);
                 }

--- a/src/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/PredicateTranslator.cs
@@ -1526,11 +1526,11 @@ namespace MongoDB.Driver.Linq.Translators
             }
 
             pattern = "^" + pattern + "$";
-            if (pattern.StartsWith("^.*"))
+            if (pattern.StartsWith("^.*", StringComparison.Ordinal))
             {
                 pattern = pattern.Substring(3);
             }
-            if (pattern.EndsWith(".*$"))
+            if (pattern.EndsWith(".*$", StringComparison.Ordinal))
             {
                 pattern = pattern.Substring(0, pattern.Length - 3);
             }

--- a/src/MongoDB.Driver/WriteModel.cs
+++ b/src/MongoDB.Driver/WriteModel.cs
@@ -126,7 +126,7 @@ namespace MongoDB.Driver
             if (update is BsonDocument updateDocument)
             {
                 var firstElementName = updateDocument.GetElement(0).Name;
-                return !firstElementName.StartsWith("$");
+                return !firstElementName.StartsWith("$", StringComparison.Ordinal);
             }
 
             if (update is BsonArray)


### PR DESCRIPTION
EG:  https://evergreen.mongodb.com/version/5e615a112a60ed01adf32583

NOTES:
1. I didn't make changes in the tests.
2. Changed methods:
* StartsWith
* EndsWith
3. Untouched methods:
* IndexOf - it's possible to have unsafe behavior with this method, but only if we use the method version with `string` input argument (we have such method only in tests). A method with a char argument performs an ordinal (culture-insensitive) search.
* Contain is safe: https://github.com/microsoft/referencesource/blob/master/mscorlib/system/string.cs#L2173
* Equals and `==`/`!=` is save: 
https://github.com/microsoft/referencesource/blob/master/mscorlib/system/string.cs#L617
https://github.com/microsoft/referencesource/blob/master/mscorlib/system/string.cs#L650
* LastIndexOf - we have only one place with this method which is used this method in a safe way
* Compare - we don't use this method to compare strings

