### PR TITLE
CSHARP-3012: Remove a server from a multiServercluster in case if the server is not valid for the current cluster.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/MultiServerCluster.cs
@@ -318,7 +318,8 @@ namespace MongoDB.Driver.Core.Clusters
                     }
                     else
                     {
-                        newClusterDescription = newClusterDescription.WithoutServerDescription(newServerDescription.EndPoint);
+                        var reason = $"The server {newServerDescription.EndPoint} with type {newServerDescription.Type} is not valid for cluster type {newClusterDescription.Type}.";
+                        newClusterDescription = RemoveServer(newClusterDescription, newServerDescription.EndPoint, reason);
                     }
                 }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/MultiServerClusterTests.cs
@@ -736,6 +736,8 @@ namespace MongoDB.Driver.Core.Clusters
             var description = subject.Description;
             description.Servers.Should().BeEquivalentToWithComparer(GetDescriptions(_firstEndPoint, _thirdEndPoint), _serverDescriptionComparer);
 
+            _capturedEvents.Next().Should().BeOfType<ClusterRemovingServerEvent>();
+            _capturedEvents.Next().Should().BeOfType<ClusterRemovedServerEvent>();
             _capturedEvents.Next().Should().BeOfType<ClusterDescriptionChangedEvent>();
             _capturedEvents.Any().Should().BeFalse();
         }
@@ -762,6 +764,8 @@ namespace MongoDB.Driver.Core.Clusters
             _capturedEvents.Next().Should().BeOfType<ClusterAddingServerEvent>();
             _capturedEvents.Next().Should().BeOfType<ClusterAddedServerEvent>();
             _capturedEvents.Next().Should().BeOfType<ClusterDescriptionChangedEvent>();
+            _capturedEvents.Next().Should().BeOfType<ClusterRemovingServerEvent>();
+            _capturedEvents.Next().Should().BeOfType<ClusterRemovedServerEvent>();
             _capturedEvents.Next().Should().BeOfType<ClusterDescriptionChangedEvent>();
             _capturedEvents.Any().Should().BeFalse();
         }

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/TestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/TestRunner.cs
@@ -14,15 +14,13 @@
 */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.TestHelpers;
+using MongoDB.Bson.TestHelpers.JsonDrivenTests;
 using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Connections;
@@ -43,9 +41,11 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         [Theory]
         [ClassData(typeof(TestCaseFactory))]
-        public void RunTestDefinition(BsonDocument definition)
+        public void RunTestDefinition(JsonDrivenTestCase testCase)
         {
-            VerifyFields(definition, "description", "path", "phases", "uri");
+            var definition = testCase.Test;
+
+            JsonDrivenHelper.EnsureAllFieldsAreValid(definition, "description", "_path", "phases", "uri");
 
             _cluster = BuildCluster(definition);
             _cluster.Initialize();
@@ -59,7 +59,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         private void ApplyPhase(BsonDocument phase)
         {
-            VerifyFields(phase, "outcome", "responses");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(phase, "outcome", "responses");
 
             var responses = phase["responses"].AsBsonArray;
             foreach (BsonArray response in responses)
@@ -80,7 +80,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
             var address = response[0].AsString;
             var isMasterDocument = response[1].AsBsonDocument;
-            VerifyFields(isMasterDocument, "arbiterOnly", "arbiters", "electionId", "hidden", "hosts", "ismaster", "isreplicaset", "logicalSessionTimeoutMinutes", "maxWireVersion", "me", "minWireVersion", "msg", "ok", "passive", "passives", "primary", "secondary", "setName", "setVersion");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(isMasterDocument, "arbiterOnly", "arbiters", "electionId", "hidden", "hosts", "ismaster", "isreplicaset", "logicalSessionTimeoutMinutes", "maxWireVersion", "me", "minWireVersion", "msg", "ok", "passive", "passives", "primary", "secondary", "setName", "setVersion");
 
             var endPoint = EndPointHelper.Parse(address);
             var isMasterResult = new IsMasterResult(isMasterDocument);
@@ -97,17 +97,6 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
             var currentClusterDescription = _cluster.Description;
             _serverFactory.PublishDescription(newServerDescription);
             SpinWait.SpinUntil(() => !object.ReferenceEquals(_cluster.Description, currentClusterDescription), 100); // sometimes returns false and that's OK
-        }
-
-        private void VerifyFields(BsonDocument document, params string[] expectedNames)
-        {
-            foreach (var name in document.Names)
-            {
-                if (!expectedNames.Contains(name))
-                {
-                    throw new FormatException($"Invalid field: \"{name}\".");
-                }
-            }
         }
 
         private void VerifyTopology(ICluster cluster, string expectedType)
@@ -141,7 +130,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         private void VerifyOutcome(BsonDocument outcome)
         {
-            VerifyFields(outcome, "compatible", "logicalSessionTimeoutMinutes", "servers", "setName", "topologyType");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(outcome, "compatible", "logicalSessionTimeoutMinutes", "servers", "setName", "topologyType");
 
             var expectedTopologyType = (string)outcome["topologyType"];
             VerifyTopology(_cluster, expectedTopologyType);
@@ -194,7 +183,7 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
 
         private void VerifyServerDescription(ServerDescription actualDescription, BsonDocument expectedDescription)
         {
-            VerifyFields(expectedDescription, "electionId", "setName", "setVersion", "type");
+            JsonDrivenHelper.EnsureAllFieldsAreValid(expectedDescription, "electionId", "setName", "setVersion", "type");
 
             var expectedType = (string)expectedDescription["type"];
             switch (expectedType)
@@ -282,38 +271,22 @@ namespace MongoDB.Driver.Specifications.server_discovery_and_monitoring
                 .CreateCluster();
         }
 
-        private class TestCaseFactory : IEnumerable<object[]>
+        private class TestCaseFactory : JsonDrivenTestCaseFactory
         {
-            public IEnumerator<object[]> GetEnumerator()
+            // private constants
+            private const string MonitoringPrefix = "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring.";
+
+            protected override string PathPrefix => "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.";
+
+            protected override IEnumerable<JsonDrivenTestCase> CreateTestCases(BsonDocument document)
             {
-                const string prefix = "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.";
-                const string monitoringPrefix = "MongoDB.Driver.Core.Tests.Specifications.server_discovery_and_monitoring.tests.monitoring.";
-                var executingAssembly = typeof(TestCaseFactory).GetTypeInfo().Assembly;
-                var enumerable = executingAssembly
-                    .GetManifestResourceNames()
-                    .Where(path => path.StartsWith(prefix) && path.EndsWith(".json"))
-                    .Where(path => !path.StartsWith(monitoringPrefix))
-                    .Select(path => ReadDefinition(path))
-                    .Select(definition => new object[] { definition });
-                return enumerable.GetEnumerator();
+                var name = GetTestCaseName(document, document, 0);
+                yield return new JsonDrivenTestCase(name, document, document);
             }
 
-            IEnumerator IEnumerable.GetEnumerator()
+            protected override bool ShouldReadJsonDocument(string path)
             {
-                return GetEnumerator();
-            }
-
-            private static BsonDocument ReadDefinition(string path)
-            {
-                var executingAssembly = typeof(TestCaseFactory).GetTypeInfo().Assembly;
-                using (var definitionStream = executingAssembly.GetManifestResourceStream(path))
-                using (var definitionStringReader = new StreamReader(definitionStream))
-                {
-                    var definitionString = definitionStringReader.ReadToEnd();
-                    var definition = BsonDocument.Parse(definitionString);
-                    definition.InsertAt(0, new BsonElement("path", path));
-                    return definition;
-                }
+                return base.ShouldReadJsonDocument(path) && !path.StartsWith(MonitoringPrefix);
             }
         }
     }

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/repeated.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/repeated.json
@@ -1,0 +1,140 @@
+{
+  "description": "Repeated ismaster response must be processed",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "hidden": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "c:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/repeated.yml
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/rs/repeated.yml
@@ -1,0 +1,101 @@
+description: Repeated ismaster response must be processed
+
+uri: "mongodb://a,b/?replicaSet=rs"
+
+phases:
+  # Phase 1 - a says it's not primary and suggests c may be the primary
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: false
+        secondary: true
+        hidden: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+        
+        "c:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 2 - c says it's a standalone, is removed
+  - responses:
+    -
+      - "c:27017"
+      - ok: 1
+        ismaster: true
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 3 - response from a is repeated, and must be processed; c added again
+  - responses:
+    -
+      - "a:27017"
+      - ok: 1
+        ismaster: false
+        secondary: true
+        hidden: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "b:27017":
+          type: Unknown
+        
+        "c:27017":
+          type: Unknown
+      topologyType: "ReplicaSetNoPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"
+
+  # Phase 4 - c is now a primary
+  - responses:
+    -
+      - "c:27017"
+      - ok: 1
+        ismaster: true
+        hosts: ["a:27017", "c:27017"]
+        setName: "rs"
+        minWireVersion: 0
+        maxWireVersion: 6
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSOther"
+          setName: "rs"
+        
+        "c:27017":
+          type: RSPrimary
+          setName: rs
+      topologyType: "ReplicaSetWithPrimary"
+      logicalSessionTimeoutMinutes: ~
+      setName: "rs"


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e6bd9f6850e6164cf397177

NOTE: I decided that it could be simpler just to make two separate PRs. 
As soon as it will be LGTMed, I will merge this change to PR for CSHARP-2820