### PR TITLE
CSHARP-3017: Ensure that the WriteConcernError "errInfo" object is propagated.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
+++ b/src/MongoDB.Driver.Core/Core/Misc/Feature.cs
@@ -54,6 +54,7 @@ namespace MongoDB.Driver.Core.Misc
         private static readonly Feature __explainCommand = new Feature("ExplainCommand", new SemanticVersion(3, 0, 0));
         private static readonly Feature __failPoints = new Feature("FailPoints", new SemanticVersion(2, 4, 0));
         private static readonly Feature __failPointsFailCommand = new Feature("FailPointsFailCommand", new SemanticVersion(4, 0, 0));
+        private static readonly Feature __failPointsFailCommandForSharded = new Feature("FailPointsFailCommandForSharded", new SemanticVersion(4, 1, 5));
         private static readonly Feature __findAndModifyWriteConcern = new Feature("FindAndModifyWriteConcern", new SemanticVersion(3, 2, 0));
         private static readonly Feature __findCommand = new Feature("FindCommand", new SemanticVersion(3, 2, 0));
         private static readonly Feature __geoNearCommand = new Feature("GeoNearCommand", new SemanticVersion(1, 0, 0), new SemanticVersion(4, 1, 0, ""));
@@ -241,6 +242,11 @@ namespace MongoDB.Driver.Core.Misc
         /// Gets the fail points fail command feature.
         /// </summary>
         public static Feature FailPointsFailCommand => __failPointsFailCommand;
+
+        /// <summary>
+        /// Gets the fail points fail command for sharded feature.
+        /// </summary>
+        public static Feature FailPointsFailCommandForSharded => __failPointsFailCommandForSharded;
 
         /// <summary>
         /// Gets the find and modify write concern feature.

--- a/tests/MongoDB.Driver.Tests/MongoCollectionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionProseTests.cs
@@ -29,10 +29,10 @@ namespace MongoDB.Driver.Tests
         [SkippableFact]
         public void WriteConcernError_errInfo_should_be_propagated()
         {
-            var feature = CoreTestConfiguration.Cluster.Description.Type == ClusterType.Sharded
+            var failPointFeature = CoreTestConfiguration.Cluster.Description.Type == ClusterType.Sharded
                 ? Feature.FailPointsFailCommandForSharded
                 : Feature.FailPointsFailCommand;
-            RequireServer.Check().Supports(feature);
+            RequireServer.Check().Supports(failPointFeature);
 
             var failPointCommand = @"
                 {

--- a/tests/MongoDB.Driver.Tests/MongoCollectionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionProseTests.cs
@@ -36,23 +36,23 @@ namespace MongoDB.Driver.Tests
 
             var failPointCommand = @"
                 {
-                    'configureFailPoint' : 'failCommand',
-                    'data' : {
-                        'failCommands' : ['insert'],
-                        'writeConcernError' : {
-                            'code' : 100,
-                            'codeName' : 'UnsatisfiableWriteConcern',
-                            'errmsg' : 'Not enough data-bearing nodes',
-                            'errInfo' : {
-                                'writeConcern' : {
-                                    'w' : 2,
-                                    'wtimeout' : 0,
-                                    'provenance' : 'clientSupplied'
+                    configureFailPoint : 'failCommand',
+                    data : {
+                        failCommands : ['insert'],
+                        writeConcernError : {
+                            code : 100,
+                            codeName : 'UnsatisfiableWriteConcern',
+                            errmsg : 'Not enough data-bearing nodes',
+                            errInfo : {
+                                writeConcern : {
+                                    w : 2,
+                                    wtimeout : 0,
+                                    provenance : 'clientSupplied'
                                 }
                             }
                         }
                     },
-                    'mode': { 'times': 1 }
+                    mode: { times: 1 }
                 }";
 
             using (ConfigureFailPoint(failPointCommand))
@@ -68,7 +68,7 @@ namespace MongoDB.Driver.Tests
                 var writeConcernError = e.WriteConcernError;
                 writeConcernError.Code.Should().Be(100);
                 writeConcernError.CodeName.Should().Be("UnsatisfiableWriteConcern");
-                writeConcernError.Details.Should().Be("{ 'writeConcern' : { 'w' : 2, 'wtimeout' : 0, 'provenance' : 'clientSupplied' } }");
+                writeConcernError.Details.Should().Be("{ writeConcern : { w : 2, wtimeout : 0, provenance : 'clientSupplied' } }");
                 writeConcernError.Message.Should().Be("Not enough data-bearing nodes");
             }
         }

--- a/tests/MongoDB.Driver.Tests/MongoCollectionProseTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoCollectionProseTests.cs
@@ -1,0 +1,83 @@
+﻿/* Copyright 2020-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Threading;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver.Core.Bindings;
+using MongoDB.Driver.Core.Clusters.ServerSelectors;
+using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Core.TestHelpers;
+using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
+using Xunit;
+
+namespace MongoDB.Driver.Tests
+{
+    public class MongoCollectionProseTests
+    {
+        [SkippableFact]
+        public void WriteConcernError_errInfo_should_be_propagated()
+        {
+            RequireServer.Check().Supports(Feature.FailPointsFailCommand);
+
+            var failPointCommand = @"
+                {
+                    ""configureFailPoint"" : ""failCommand"",
+                    ""data"" : {
+                        ""failCommands"" : [""insert""],
+                        ""writeConcernError"" : {
+                            ""code"" : 100,
+                            ""codeName"" : ""UnsatisfiableWriteConcern"",
+                            ""errmsg"" : ""Not enough data-bearing nodes"",
+                            ""errInfo"" : {
+                                ""writeConcern"" : {
+                                    ""w"" : 2,
+                                    ""wtimeout"" : 0,
+                                    ""provenance"" : ""clientSupplied""
+                                }
+                            }
+                        }
+                    },
+                    ""mode"": { ""times"": 1 }
+                }";
+
+            using (ConfigureFailPoint(failPointCommand))
+            {
+                var client = DriverTestConfiguration.Client;
+                var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
+                var collection = database.GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);
+
+                var exception = Record.Exception(() => collection.InsertOne(new BsonDocument()));
+
+                exception.Should().NotBeNull();
+                var e = exception.InnerException.Should().BeOfType<MongoBulkWriteException<BsonDocument>>().Subject;
+                var writeConcernError = e.WriteConcernError;
+                writeConcernError.Code.Should().Be(100);
+                writeConcernError.CodeName.Should().Be("UnsatisfiableWriteConcern");
+                writeConcernError.Details.Should().Be("{ \"writeConcern\" : { \"w\" : 2, \"wtimeout\" : 0, \"provenance\" : \"clientSupplied\" } }");
+                writeConcernError.Message.Should().Be("Not enough data-bearing nodes");
+            }
+        }
+
+        // private methods
+        private FailPoint ConfigureFailPoint(string failpointCommand)
+        {
+            var cluster = DriverTestConfiguration.Client.Cluster;
+            var server = cluster.SelectServer(WritableServerSelector.Instance, CancellationToken.None);
+            var session = NoCoreSession.NewHandle();
+            return FailPoint.Configure(cluster, session, BsonDocument.Parse(failpointCommand));
+        }
+    }
+}


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e7a30313627e0034e073190

The target of this ticket is to ensure in:
1. We don't parse writeConcernError.errInfo
2. A `"provenance": "clientSupplied"` presents in writeConcernError.errInfo.writeConcern.
3. Add a test for it.