### PR TITLE
CSHARP-2968: Exception occurs when using seedless connection string in AKS.

### DIFF
--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -114,7 +114,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DnsClient" Version="1.3.0" />
+    <PackageReference Include="DnsClient" Version="1.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.0.0" />
     <PackageReference Include="SharpCompress" Version="0.23.0" />

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -135,10 +135,6 @@
     <PackageReference Include="System.Security.SecureString" Version="4.0.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MongoDB.Bson\MongoDB.Bson.csproj" />

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -114,7 +114,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DnsClient" Version="1.2.0" />
+    <PackageReference Include="DnsClient" Version="1.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.0.0" />
     <PackageReference Include="SharpCompress" Version="0.23.0" />
@@ -129,11 +129,15 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Security.SecureString" Version="4.0.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/DnsClientWrapperTests.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using DnsClient;
 using FluentAssertions;
 using MongoDB.Driver.Core.Misc;
 using Xunit;
@@ -105,7 +106,7 @@ namespace MongoDB.Driver.Core.Clusters
                 exception = Record.Exception(() => subject.ResolveSrvRecordsAsync(service, cts.Token).GetAwaiter().GetResult());
             }
 
-            exception.Should().BeOfType<OperationCanceledException>();
+            exception.Should().Match<Exception>(e => e is OperationCanceledException || e.InnerException is OperationCanceledException);
         }
 
         [Theory]
@@ -171,7 +172,7 @@ namespace MongoDB.Driver.Core.Clusters
                 exception = Record.Exception(() => subject.ResolveTxtRecordsAsync(domainName, cts.Token).GetAwaiter().GetResult());
             }
 
-            exception.Should().BeOfType<OperationCanceledException>();
+            exception.Should().Match<Exception>(e => e is OperationCanceledException || e.InnerException is OperationCanceledException);
         }
     }
 }

--- a/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DnsClient" Version="1.2.0" />
+    <PackageReference Include="DnsClient" Version="1.3.0" />
     <PackageReference Include="FluentAssertions" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />

--- a/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
+++ b/tests/MongoDB.Driver.Core.Tests/MongoDB.Driver.Core.Tests.csproj
@@ -39,7 +39,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DnsClient" Version="1.3.0" />
     <PackageReference Include="FluentAssertions" Version="4.12.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e7ce4fbd1fe0738b7be553e

The scope of this ticket is updating a DnsClient nuget version on the latest. 