### PR TITLE
CSHARP-2989: Fix test.

### DIFF
--- a/tests/MongoDB.Driver.Tests/AggregateFluentTests.cs
+++ b/tests/MongoDB.Driver.Tests/AggregateFluentTests.cs
@@ -304,7 +304,11 @@ namespace MongoDB.Driver.Tests
                 { "maxCopies", new BsonDocument("$max", "$copies") }
             };
 
-            var result = collection.Aggregate().Group(groupProjection).ToList();
+            var result = collection
+                .Aggregate()
+                .Group(groupProjection)
+                .Sort("{ _id : 1 }")
+                .ToList();
 
             result.Count.Should().Be(2);
             result[0].Should().Be("{ _id : 'Dante', minCopies : 1, avgCopies : 1.6666666666666667, maxCopies : 2 }");


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e937f6732f4172f9105f6eb

In the ticket 2989, the order of aggregate results can be different in different test runs. So, sometimes the ticket test can fail with this error: https://evergreen.mongodb.com/task_log_raw/dot_net_driver_secure_tests__version~4.4_os~windows_64_topology~sharded_cluster_auth~auth_ssl~ssl_test_patch_44c4d03ebf5fd2bc1cd62431f3cf75c80fbd1b89_5e924c69a4cf475229cd75be_20_04_11_23_02_02/0?type=T#L4617