### PR TITLE
CSHARP-2963: And filter with $near translates to invalid MongoDb query.

### DIFF
--- a/src/MongoDB.Driver/FilterDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/FilterDefinitionBuilder.cs
@@ -1494,7 +1494,7 @@ namespace MongoDB.Driver
     internal sealed class AndFilterDefinition<TDocument> : FilterDefinition<TDocument>
     {
         #region static
-        private static readonly string[] __operatorsThatCantBeCombined = new[]
+        private static readonly string[] __operatorsThatCannotBeCombined = new[]
         {
             "$geoWithin",
             "$near",
@@ -1555,7 +1555,7 @@ namespace MongoDB.Driver
                 {
                     var clauseOperator = clauseValue.ElementCount > 0 ? clauseValue.GetElement(0).Name : null;
                     if (clauseValue.Names.Any(op => existingClauseValue.Contains(op)) ||
-                        __operatorsThatCantBeCombined.Contains(clauseOperator))
+                        __operatorsThatCannotBeCombined.Contains(clauseOperator))
                     {
                         PromoteFilterToDollarForm(document, clause);
                     }

--- a/src/MongoDB.Driver/FilterDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/FilterDefinitionBuilder.cs
@@ -1494,7 +1494,7 @@ namespace MongoDB.Driver
     internal sealed class AndFilterDefinition<TDocument> : FilterDefinition<TDocument>
     {
         #region static
-        private static readonly string[] __filtersThatAllowOnlyDollarForm = new[]
+        private static readonly string[] __operatorsThatCantBeCombined = new[]
         {
             "$geoWithin",
             "$near",
@@ -1553,9 +1553,9 @@ namespace MongoDB.Driver
                 var existingClause = document.GetElement(clause.Name);
                 if (existingClause.Value is BsonDocument existingClauseValue && clause.Value is BsonDocument clauseValue)
                 {
-                    var topLevelElementName = clauseValue.ElementCount > 0 ? clauseValue.GetElement(0).Name : null;
-                    if (__filtersThatAllowOnlyDollarForm.Contains(topLevelElementName) ||
-                        clauseValue.Names.Any(op => existingClauseValue.Contains(op)))
+                    var clauseOperator = clauseValue.ElementCount > 0 ? clauseValue.GetElement(0).Name : null;
+                    if (clauseValue.Names.Any(op => existingClauseValue.Contains(op)) ||
+                        __operatorsThatCantBeCombined.Contains(clauseOperator))
                     {
                         PromoteFilterToDollarForm(document, clause);
                     }

--- a/src/MongoDB.Driver/FilterDefinitionBuilder.cs
+++ b/src/MongoDB.Driver/FilterDefinitionBuilder.cs
@@ -1493,6 +1493,16 @@ namespace MongoDB.Driver
 
     internal sealed class AndFilterDefinition<TDocument> : FilterDefinition<TDocument>
     {
+        #region static
+        private static readonly string[] __filtersThatAllowOnlyDollarForm = new[]
+        {
+            "$geoWithin",
+            "$near",
+            "$geoIntersects",
+            "$nearSphere"
+        };
+        #endregion
+
         private readonly List<FilterDefinition<TDocument>> _filters;
 
         public AndFilterDefinition(IEnumerable<FilterDefinition<TDocument>> filters)
@@ -1541,11 +1551,11 @@ namespace MongoDB.Driver
             else if (document.Contains(clause.Name))
             {
                 var existingClause = document.GetElement(clause.Name);
-                if (existingClause.Value is BsonDocument && clause.Value is BsonDocument)
+                if (existingClause.Value is BsonDocument existingClauseValue && clause.Value is BsonDocument clauseValue)
                 {
-                    var clauseValue = (BsonDocument)clause.Value;
-                    var existingClauseValue = (BsonDocument)existingClause.Value;
-                    if (clauseValue.Names.Any(op => existingClauseValue.Contains(op)))
+                    var topLevelElementName = clauseValue.ElementCount > 0 ? clauseValue.GetElement(0).Name : null;
+                    if (__filtersThatAllowOnlyDollarForm.Contains(topLevelElementName) ||
+                        clauseValue.Names.Any(op => existingClauseValue.Contains(op)))
                     {
                         PromoteFilterToDollarForm(document, clause);
                     }

--- a/tests/MongoDB.Driver.Tests/FilterDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/FilterDefinitionBuilderTests.cs
@@ -78,6 +78,20 @@ namespace MongoDB.Driver.Tests
             Assert(filter, "{a: {$gt: 1, $lt: 10}}");
         }
 
+        [Theory]
+        [InlineData("{ geoField : { $geoWithin : { $box : [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] } } }", "{ geoField : { $near : [ 5.0, 6.0 ] } }")]
+        [InlineData("{ geoField : { $near : [ 5.0, 6.0 ] } }", "{ geoField : { $geoWithin : { $box : [ [ 1.0, 2.0 ], [ 3.0, 4.0 ] ] } } }")]
+        [InlineData("{ geoField : { $nearSphere : { $geometry : { type : 'Point', coordinates : [ 1, 2 ] } } } }", "{ geoField : { $geoIntersects : { $geometry : { type : 'Polygon', coordinates: [ [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ], [ 7, 8 ] ] ] } } } }")]
+        [InlineData("{ geoField : { $geoIntersects : { $geometry : { type : 'Polygon', coordinates: [ [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ], [ 7, 8 ] ] ] } } } }", "{ geoField : { $nearSphere : { $geometry : { type : 'Point', coordinates : [ 1, 2 ] } } } }")]
+        public void And_with_clashing_keys_and_different_operators_but_with_filters_that_support_only_dollar_form_should_get_promoted_to_dollar_form(string firstFilter, string secondFilter)
+        {
+            var subject = CreateSubject<BsonDocument>();
+
+            var combinedFilter = subject.And(firstFilter, secondFilter);
+
+            Assert(combinedFilter, $"{{ $and : [ {firstFilter}, {secondFilter} ] }}");
+        }
+
         [Fact]
         public void And_with_an_empty_filter()
         {

--- a/tests/MongoDB.Driver.Tests/FilterDefinitionBuilderTests.cs
+++ b/tests/MongoDB.Driver.Tests/FilterDefinitionBuilderTests.cs
@@ -93,6 +93,18 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public void And_with_clashing_keys_and_different_operators_but_with_filters_that_support_only_dollar_form_and_empty_filter_should_ignore_empty_filter()
+        {
+            var subject = CreateSubject<BsonDocument>();
+
+            var combinedFilter = subject.And(
+                "{ geoField : { $near : [ 5.0, 6.0 ] } }",
+                "{ geoField : { } }");
+
+            Assert(combinedFilter, "{ geoField : { $near : [ 5.0, 6.0 ] } }");
+        }
+
+        [Fact]
         public void And_with_an_empty_filter()
         {
             var subject = CreateSubject<BsonDocument>();


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5e94ea34e3c3312519b63a7a