### PR TITLE
CSHARP-3061: Clarify how a driver must handle wrong set name in single topology.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Clusters/SingleServerCluster.cs
+++ b/src/MongoDB.Driver.Core/Core/Clusters/SingleServerCluster.cs
@@ -179,12 +179,12 @@ namespace MongoDB.Driver.Core.Clusters
             var newServerDescription = args.NewServerDescription;
             var newClusterDescription = Description;
 
-            if (_replicaSetName != null && newServerDescription.ReplicaSetConfig != null)
+            if (_replicaSetName != null)
             {
-                var isMasterSetName = newServerDescription.ReplicaSetConfig.Name;
-                if (isMasterSetName == null || _replicaSetName != isMasterSetName)
+                var replicaSetConfig = newServerDescription.ReplicaSetConfig;
+                if (replicaSetConfig == null || replicaSetConfig.Name != _replicaSetName)
                 {
-                    // in this case setName is considered as wrong, so the ServerDescription MUST be replaced with a default ServerDescription of type Unknown
+                    // if the replica set name does not match then the ServerType in the ServerDescription MUST be replaced with Unknown
                     newServerDescription = newServerDescription.With(type: ServerType.Unknown);
                 }
             }

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -810,7 +810,7 @@ namespace MongoDB.Driver.Core.Configuration
 
             if (_connect.HasValue && _directConnection.HasValue)
             {
-                throw new MongoConfigurationException("Specifying both connect and directConnection is invalid.");
+                throw new MongoConfigurationException("Connect and directConnection cannot both be specified.");
             }
             _connect = GetEffectiveConnectionMode(_connect, _directConnection, _replicaSet);
 
@@ -827,12 +827,12 @@ namespace MongoDB.Driver.Core.Configuration
 
             if (_scheme == ConnectionStringScheme.MongoDBPlusSrv && _connect == ClusterConnectionMode.Direct)
             {
-                throw new MongoConfigurationException("Direct connect is not allowed to be used with SRV.");
+                throw new MongoConfigurationException("Direct connect cannot be used with SRV.");
             }
 
             if (_hosts.Count > 1 && _connect == ClusterConnectionMode.Direct)
             {
-                throw new MongoConfigurationException("Direct connect is not allowed to be used with multiple seeds.");
+                throw new MongoConfigurationException("Direct connect cannot be used with multiple host names.");
             }
 
             string protectConnectionString(string connectionString)
@@ -1219,7 +1219,7 @@ namespace MongoDB.Driver.Core.Configuration
             return value;
         }
 
-        private ClusterConnectionMode? GetEffectiveConnectionMode(ClusterConnectionMode? mode, bool? directConnection, string replicaSet)
+        private ClusterConnectionMode? GetEffectiveConnectionMode(ClusterConnectionMode? connect, bool? directConnection, string replicaSet)
         {
             if (directConnection.HasValue)
             {
@@ -1234,7 +1234,7 @@ namespace MongoDB.Driver.Core.Configuration
             }
             else
             {
-                return mode;
+                return connect;
             }
         }
 

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -68,9 +68,10 @@ namespace MongoDB.Driver.Core.Configuration
         private string _applicationName;
         private string _authMechanism;
         private string _authSource;
-        private ClusterConnectionMode _connect;
+        private ClusterConnectionMode? _connect;
         private TimeSpan? _connectTimeout;
         private string _databaseName;
+        private bool? _directConnection; // this option covers several cases from _connect. It won't be available outside of this class
         private bool? _fsync;
         private TimeSpan? _heartbeatInterval;
         private TimeSpan? _heartbeatTimeout;
@@ -206,7 +207,7 @@ namespace MongoDB.Driver.Core.Configuration
         /// </summary>
         public ClusterConnectionMode Connect
         {
-            get { return _connect; }
+            get { return _connect.GetValueOrDefault(); }
         }
 
         /// <summary>
@@ -807,6 +808,12 @@ namespace MongoDB.Driver.Core.Configuration
             ExtractScheme(match);
             ExtractHosts(match);
 
+            if (_connect.HasValue && _directConnection.HasValue)
+            {
+                throw new MongoConfigurationException("Specifying both connect and directConnection is invalid.");
+            }
+            _connect = GetEffectiveConnectionMode(_connect, _directConnection, _replicaSet);
+
             if (_journal.HasValue && _journal.Value && _w != null && _w.Equals(0))
             {
                 throw new MongoConfigurationException("This is an invalid w and journal pair.");
@@ -816,6 +823,16 @@ namespace MongoDB.Driver.Core.Configuration
             {
                 throw new MongoConfigurationException(
                     "Specifying both tlsInsecure and tlsDisableCertificateRevocationCheck is invalid.");
+            }
+
+            if (_scheme == ConnectionStringScheme.MongoDBPlusSrv && _connect == ClusterConnectionMode.Direct)
+            {
+                throw new MongoConfigurationException("Direct connect is not allowed to be used with SRV.");
+            }
+
+            if (_hosts.Count > 1 && _connect == ClusterConnectionMode.Direct)
+            {
+                throw new MongoConfigurationException("Direct connect is not allowed to be used with multiple seeds.");
             }
 
             string protectConnectionString(string connectionString)
@@ -858,6 +875,9 @@ namespace MongoDB.Driver.Core.Configuration
                 case "connecttimeout":
                 case "connecttimeoutms":
                     _connectTimeout = ParseTimeSpan(name, value);
+                    break;
+                case "directconnection":
+                    _directConnection = ParseBoolean(name, value);
                     break;
                 case "fsync":
                     _fsync = ParseBoolean(name, value);
@@ -1197,6 +1217,25 @@ namespace MongoDB.Driver.Core.Configuration
             }
 
             return value;
+        }
+
+        private ClusterConnectionMode? GetEffectiveConnectionMode(ClusterConnectionMode? mode, bool? directConnection, string replicaSet)
+        {
+            if (directConnection.HasValue)
+            {
+                if (directConnection.Value)
+                {
+                    return ClusterConnectionMode.Direct;
+                }
+                else
+                {
+                    return replicaSet != null ? ClusterConnectionMode.ReplicaSet : ClusterConnectionMode.Automatic;
+                }
+            }
+            else
+            {
+                return mode;
+            }
         }
 
         private List<string> GetHostsFromSrvRecords(IEnumerable<SrvRecord> srvRecords)

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/SingleServerClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/SingleServerClusterTests.cs
@@ -151,7 +151,7 @@ namespace MongoDB.Driver.Core.Clusters
 
         [Theory]
         [ParameterAttributeData]
-        public void ServerDescription_type_should_be_replaced_on_Unknown_when_isMaster_setName_wrong(
+        public void ServerDescription_type_should_be_replaced_with_Unknown_when_isMaster_setName_is_different(
             [Values(null, "wrong")] string isMasterSetName)
         {
             _settings = _settings.With(

--- a/tests/MongoDB.Driver.Core.Tests/Core/Clusters/SingleServerClusterTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Clusters/SingleServerClusterTests.cs
@@ -14,9 +14,10 @@
 */
 
 using System;
+using System.Linq;
 using System.Net;
 using FluentAssertions;
-using MongoDB.Driver.Core.Clusters;
+using MongoDB.Bson.TestHelpers.XunitExtensions;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Servers;
@@ -148,18 +149,44 @@ namespace MongoDB.Driver.Core.Clusters
             _capturedEvents.Any().Should().BeFalse();
         }
 
+        [Theory]
+        [ParameterAttributeData]
+        public void ServerDescription_type_should_be_replaced_on_Unknown_when_isMaster_setName_wrong(
+            [Values(null, "wrong")] string isMasterSetName)
+        {
+            _settings = _settings.With(
+                connectionMode: ClusterConnectionMode.Direct,
+                replicaSetName: "rs");
+
+            var subject = CreateSubject();
+            subject.Initialize();
+            _capturedEvents.Clear();
+
+            var replicaSetConfig = new ReplicaSetConfig(new[] { _endPoint }, name: isMasterSetName, _endPoint, 1);
+            PublishDescription(_endPoint, ServerType.Standalone, replicaSetConfig);
+
+            subject.Description.Type.Should().Be(ClusterType.Unknown);
+            var resultServers = subject.Description.Servers;
+            resultServers.Count.Should().Be(1);
+            resultServers.First().Type.Should().Be(ServerType.Unknown);
+            _capturedEvents.Next().Should().BeOfType<ClusterDescriptionChangedEvent>();
+            _capturedEvents.Any().Should().BeFalse();
+        }
+
+        // private methods
         private SingleServerCluster CreateSubject()
         {
             return new SingleServerCluster(_settings, _mockServerFactory, _capturedEvents);
         }
 
-        private void PublishDescription(EndPoint endPoint, ServerType serverType)
+        private void PublishDescription(EndPoint endPoint, ServerType serverType, ReplicaSetConfig replicaSetConfig = null)
         {
             var current = _mockServerFactory.GetServerDescription(endPoint);
 
             var description = current.With(
                 state: ServerState.Connected,
-                type: serverType);
+                type: serverType,
+                replicaSetConfig: replicaSetConfig);
 
             _mockServerFactory.PublishDescription(description);
         }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
@@ -515,6 +515,59 @@ namespace MongoDB.Driver.Core.Configuration
         }
 
         [Theory]
+        [InlineData("mongodb://localhost/?directConnection=true&replicaSet=yeah", true, ClusterConnectionMode.Direct)]
+        [InlineData("mongodb://localhost/?directConnection=true", true, ClusterConnectionMode.Direct)]
+        [InlineData("mongodb://localhost/?directConnection=false&replicaSet=yeah", false, ClusterConnectionMode.ReplicaSet)]
+        [InlineData("mongodb://localhost/?directConnection=false", false, ClusterConnectionMode.Automatic)]
+        public void When_a_directConenction_is_specified(string connectionString, bool directConnection, ClusterConnectionMode mode)
+        {
+            var subject = new ConnectionString(connectionString);
+
+            var result = bool.Parse(subject.GetOption("directConnection"));
+            result.Should().Be(directConnection);
+        }
+
+        [Theory]
+        [InlineData("mongodb+srv://localhost/?directConnection=false", false)]
+        [InlineData("mongodb+srv://localhost/?directConnection=true", true)]
+        public void When_a_directConnection_is_specified_with_a_srv_scheme(string connectionString, bool shouldThrow)
+        {
+            ConnectionString result = null;
+            var exception = Record.Exception(() => result = new ConnectionString(connectionString));
+
+            if (shouldThrow)
+            {
+                exception.Should().BeOfType<MongoConfigurationException>();
+            }
+            else
+            {
+                exception.Should().BeNull();
+                var directConnection = bool.Parse(result.GetOption("directConnection"));
+                directConnection.Should().BeFalse();
+            }
+        }
+
+        [Theory]
+        [InlineData("mongodb://localhost1,localhost2/?directConnection=false", false)]
+        [InlineData("mongodb://localhost1,localhost2/?directConnection=true", true)]
+        public void When_a_directConnection_is_specified_with_multiple_seeds(string connectionString, bool shouldThrow)
+        {
+            ConnectionString result = null;
+            var exception = Record.Exception(() => result = new ConnectionString(connectionString));
+
+            if (shouldThrow)
+            {
+                exception.Should().BeOfType<MongoConfigurationException>();
+            }
+            else
+            {
+                exception.Should().BeNull();
+                var directConnection = bool.Parse(result.GetOption("directConnection"));
+                directConnection.Should().BeFalse();
+            }
+        }
+
+        [Theory]
         [InlineData("mongodb://localhost?fsync=true", true)]
         [InlineData("mongodb://localhost?fsync=false", false)]
         public void When_fsync_is_specified(string connectionString, bool fsync)

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/single/direct_connection_wrong_set_name.json
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/server-discovery-and-monitoring/tests/single/direct_connection_wrong_set_name.json
@@ -1,0 +1,63 @@
+{
+  "description": "Direct connection to RSPrimary with wrong set name",
+  "uri": "mongodb://a/?directConnection=true&replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "wrong",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "Single",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
+++ b/tests/MongoDB.Driver.Tests/MongoClientSettingsTests.cs
@@ -493,7 +493,6 @@ namespace MongoDB.Driver.Tests
         }
 
         [Theory]
-        [InlineData("mongodb+srv://username:password@test5.test.build.10gen.cc/?connect=direct", ConnectionStringScheme.MongoDB, "localhost.test.build.10gen.cc:27017")]
         [InlineData("mongodb+srv://username:password@test5.test.build.10gen.cc/?connect=standalone", ConnectionStringScheme.MongoDB, "localhost.test.build.10gen.cc:27017")]
         [InlineData("mongodb+srv://username:password@test5.test.build.10gen.cc/?connect=automatic",  ConnectionStringScheme.MongoDBPlusSrv, "test5.test.build.10gen.cc:53")]
         [InlineData("mongodb+srv://username:password@test5.test.build.10gen.cc/?connect=replicaset", ConnectionStringScheme.MongoDBPlusSrv, "test5.test.build.10gen.cc:53")]


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5ea76fd25623435bc78830bc