### PR TITLE
CSHARP-3180: Use server error codes in place of error messages when possible.

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Operations/DropCollectionOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/DropCollectionOperation.cs
@@ -13,7 +13,6 @@
 * limitations under the License.
 */
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;
@@ -158,7 +157,9 @@ namespace MongoDB.Driver.Core.Operations
 
         private bool ShouldIgnoreException(MongoCommandException ex)
         {
-            return ex.ErrorMessage == "ns not found";
+            return
+                ex.Code == (int)ServerErrorCode.NamespaceNotFound ||
+                ex.ErrorMessage == "ns not found";
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/Operations/DropIndexOperation.cs
+++ b/src/MongoDB.Driver.Core/Core/Operations/DropIndexOperation.cs
@@ -200,7 +200,9 @@ namespace MongoDB.Driver.Core.Operations
 
         private bool ShouldIgnoreException(MongoCommandException ex)
         {
-            return ex.ErrorMessage != null && ex.ErrorMessage.Contains("ns not found");
+            return
+                ex.Code == (int)ServerErrorCode.NamespaceNotFound ||
+                ex.ErrorMessage != null && ex.ErrorMessage.Contains("ns not found");
         }
     }
 }

--- a/src/MongoDB.Driver.Core/ServerErrorCode.cs
+++ b/src/MongoDB.Driver.Core/ServerErrorCode.cs
@@ -30,6 +30,8 @@ namespace MongoDB.Driver
         Interrupted = 11601,
         InterruptedAtShutdown = 11600,
         InterruptedDueToReplStateChange = 11602,
+        MaxTimeMSExpired = 50,
+        NamespaceNotFound = 26,
         NetworkTimeout = 89,
         NotMaster = 10107,
         NotMasterNoSlaveOk = 13435,
@@ -43,8 +45,6 @@ namespace MongoDB.Driver
         StaleShardVersion = 63,
         UnknownReplWriteConcern = 79,
         UnsatisfiableWriteConcern = 100,
-        WriteConcernFailed = 64,
-        MaxTimeMSExpired = 50,
-        NamespaceNotFound = 26
+        WriteConcernFailed = 64
     }
 }

--- a/src/MongoDB.Driver.Core/ServerErrorCode.cs
+++ b/src/MongoDB.Driver.Core/ServerErrorCode.cs
@@ -44,6 +44,7 @@ namespace MongoDB.Driver
         UnknownReplWriteConcern = 79,
         UnsatisfiableWriteConcern = 100,
         WriteConcernFailed = 64,
-        MaxTimeMSExpired = 50
+        MaxTimeMSExpired = 50,
+        NamespaceNotFound = 26
     }
 }


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5f616d5d7742ae771d51d0ed