### PR TITLE
CSHARP-3241: Zstandard compression key in the code must be kept in sync with the spec (Follow-up).

### DIFF
--- a/src/MongoDB.Driver.Core/Core/Compression/CompressorTypeMapper.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/CompressorTypeMapper.cs
@@ -1,0 +1,53 @@
+﻿/* Copyright 2020–present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+namespace MongoDB.Driver.Core.Compression
+{
+    internal static class CompressorTypeMapper
+    {
+        public static string ToServerName(CompressorType compressorType)
+        {
+            switch (compressorType)
+            {
+                case CompressorType.Noop:
+                    return "noop";
+                case CompressorType.Zlib:
+                    return "zlib";
+                case CompressorType.Snappy:
+                    return "snappy";
+                case CompressorType.ZStandard:
+                    return "zstd";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(compressorType));
+            }
+        }
+
+        public static bool TryFromServerName(string serverName, out CompressorType compressorType)
+        {
+            compressorType = default;
+            switch (serverName)
+            {
+                case "noop": compressorType = CompressorType.Noop; break;
+                case "zlib": compressorType = CompressorType.Zlib; break;
+                case "snappy": compressorType = CompressorType.Snappy; break;
+                case "zstd": compressorType = CompressorType.ZStandard; break;
+                default: return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/MongoDB.Driver.Core/Core/Compression/CompressorTypeMapper.cs
+++ b/src/MongoDB.Driver.Core/Core/Compression/CompressorTypeMapper.cs
@@ -39,7 +39,7 @@ namespace MongoDB.Driver.Core.Compression
         public static bool TryFromServerName(string serverName, out CompressorType compressorType)
         {
             compressorType = default;
-            switch (serverName)
+            switch (serverName.ToLowerInvariant())
             {
                 case "noop": compressorType = CompressorType.Noop; break;
                 case "zlib": compressorType = CompressorType.Zlib; break;

--- a/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
+++ b/src/MongoDB.Driver.Core/Core/Configuration/ConnectionString.cs
@@ -1420,7 +1420,7 @@ namespace MongoDB.Driver.Core.Configuration
                 foreach (var compressor in compressorNames)
                 {
                     // NOTE: the 'noop' is also expected by the server
-                    if (!Enum.TryParse(compressor, true, out CompressorType compressorType) || !CompressorSource.IsCompressorSupported(compressorType))
+                    if (!CompressorTypeMapper.TryFromServerName(compressor, out CompressorType compressorType) || !CompressorSource.IsCompressorSupported(compressorType))
                     {
                         // Keys that aren't supported by a driver MUST be ignored.
                         continue;

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterHelper.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterHelper.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver.Core.Authentication;
+using MongoDB.Driver.Core.Compression;
 using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Misc;
 using MongoDB.Driver.Core.Servers;
@@ -37,7 +38,7 @@ namespace MongoDB.Driver.Core.Connections
 
         internal static BsonDocument AddCompressorsToCommand(BsonDocument command, IEnumerable<CompressorConfiguration> compressors)
         {
-            var compressorsArray = new BsonArray(compressors.Select(x => x.Type.ToString().ToLowerInvariant()));
+            var compressorsArray = new BsonArray(compressors.Select(x => CompressorTypeMapper.ToServerName(x.Type)));
 
             return command.Add("compression", compressorsArray);
         }

--- a/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
+++ b/src/MongoDB.Driver.Core/Core/Connections/IsMasterResult.cs
@@ -57,7 +57,7 @@ namespace MongoDB.Driver.Core.Connections
                         .AsBsonArray
                         .Select(x =>
                         {
-                            return Enum.TryParse<CompressorType>(x.AsString, true, out var compressorType)
+                            return CompressorTypeMapper.TryFromServerName(x.AsString, out var compressorType)
                                 ? compressorType
                                 // we can have such a case only due to the server bug
                                 : throw new NotSupportedException($"The unsupported compressor name: '{x}'.");

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
@@ -453,9 +453,13 @@ namespace MongoDB.Driver.Core.Configuration
 
         [Theory]
         [InlineData("mongodb://localhost?compressors=noop", CompressorType.Noop)]
+        [InlineData("mongodb://localhost?compressors=nooP", CompressorType.Noop)]
         [InlineData("mongodb://localhost?compressors=zlib", CompressorType.Zlib)]
+        [InlineData("mongodb://localhost?compressors=Zlib", CompressorType.Zlib)]
         [InlineData("mongodb://localhost?compressors=snappy", CompressorType.Snappy)]
+        [InlineData("mongodb://localhost?compressors=Snappy", CompressorType.Snappy)]
         [InlineData("mongodb://localhost?compressors=zstd", CompressorType.ZStandard)]
+        [InlineData("mongodb://localhost?compressors=Zstd", CompressorType.ZStandard)]
         public void When_compressor_is_specified(string connectionString, CompressorType compressor)
         {
             var subject = new ConnectionString(connectionString);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Configuration/ConnectionStringTests.cs
@@ -452,7 +452,10 @@ namespace MongoDB.Driver.Core.Configuration
         }
 
         [Theory]
+        [InlineData("mongodb://localhost?compressors=noop", CompressorType.Noop)]
         [InlineData("mongodb://localhost?compressors=zlib", CompressorType.Zlib)]
+        [InlineData("mongodb://localhost?compressors=snappy", CompressorType.Snappy)]
+        [InlineData("mongodb://localhost?compressors=zstd", CompressorType.ZStandard)]
         public void When_compressor_is_specified(string connectionString, CompressorType compressor)
         {
             var subject = new ConnectionString(connectionString);

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionDescriptionTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/ConnectionDescriptionTests.cs
@@ -31,13 +31,13 @@ namespace MongoDB.Driver.Core.Connections
             "{ ok: 1, version: \"2.6.3\" }"
         ));
 
-        private static readonly IEnumerable<CompressorType> __compressors = new[] { CompressorType.Zlib };
+        private static readonly IEnumerable<CompressorType> __compressors = new[] { CompressorType.Zlib, CompressorType.ZStandard };
 
         private static readonly ConnectionId __connectionId = new ConnectionId(
             new ServerId(new ClusterId(), new DnsEndPoint("localhost", 27017)));
 
         private static readonly IsMasterResult __isMasterResult = new IsMasterResult(BsonDocument.Parse(
-            "{ ok: 1, maxWriteBatchSize: 10, maxBsonObjectSize: 20, maxMessageSizeBytes: 30, compression: ['zlib'] }"
+            "{ ok: 1, maxWriteBatchSize: 10, maxBsonObjectSize: 20, maxMessageSizeBytes: 30, compression: ['zlib', 'zstd'] }"
         ));
 
         private static readonly IsMasterResult __isMasterResultWithoutCompression = new IsMasterResult(BsonDocument.Parse(
@@ -57,7 +57,7 @@ namespace MongoDB.Driver.Core.Connections
         {
             var subject = new ConnectionDescription(__connectionId, __isMasterResult, __buildInfoResult);
 
-            subject.AvailableCompressors.Count.Should().Be(1);
+            subject.AvailableCompressors.Count.Should().Be(2);
             subject.AvailableCompressors.Should().Equal(__compressors);
         }
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterHelperTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterHelperTests.cs
@@ -71,7 +71,8 @@ namespace MongoDB.Driver.Core.Connections
                 new CompressorType[] { },
                 new [] { CompressorType.Zlib },
                 new [] { CompressorType.Snappy},
-                new [] { CompressorType.Zlib, CompressorType.Snappy })]
+                new [] { CompressorType.Zlib, CompressorType.Snappy },
+                new [] { CompressorType.ZStandard, CompressorType.Snappy })]
             CompressorType[] compressorsParameters)
         {
             var command = IsMasterHelper.CreateCommand();
@@ -81,7 +82,7 @@ namespace MongoDB.Driver.Core.Connections
                     .ToArray();
             var result = IsMasterHelper.AddCompressorsToCommand(command, compressors);
 
-            var expectedCompressions = string.Join(",", compressorsParameters.Select(c => $"'{c.ToString().ToLowerInvariant()}'"));
+            var expectedCompressions = string.Join(",", compressorsParameters.Select(c => $"'{CompressorTypeMapper.ToServerName(c)}'"));
             result.Should().Be(BsonDocument.Parse($"{{ isMaster : 1, compression: [{expectedCompressions}] }}"));
         }
     }

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
@@ -29,9 +29,13 @@ namespace MongoDB.Driver.Core.Connections
     {
         [Theory]
         [InlineData("{ compression : ['zlib'] }", new[] { CompressorType.Zlib })]
+        [InlineData("{ compression : ['Zlib'] }", new[] { CompressorType.Zlib })]
         [InlineData("{ compression : ['zlib', 'snappy'] }", new[] { CompressorType.Zlib, CompressorType.Snappy })]
+        [InlineData("{ compression : ['zlib', 'snAppy'] }", new[] { CompressorType.Zlib, CompressorType.Snappy })]
         [InlineData("{ compression : ['noop'] }", new[] { CompressorType.Noop })]
+        [InlineData("{ compression : ['nOop'] }", new[] { CompressorType.Noop })]
         [InlineData("{ compression : ['zstd'] }", new[] { CompressorType.ZStandard})]
+        [InlineData("{ compression : ['zsTd'] }", new[] { CompressorType.ZStandard })]
         [InlineData("{ compression : [] }", new CompressorType[0])]
         [InlineData("{ }", new CompressorType[0])]
         public void Compression_should_parse_document_correctly(string json, CompressorType[] expectedCompression)

--- a/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Connections/IsMasterResultTests.cs
@@ -31,6 +31,7 @@ namespace MongoDB.Driver.Core.Connections
         [InlineData("{ compression : ['zlib'] }", new[] { CompressorType.Zlib })]
         [InlineData("{ compression : ['zlib', 'snappy'] }", new[] { CompressorType.Zlib, CompressorType.Snappy })]
         [InlineData("{ compression : ['noop'] }", new[] { CompressorType.Noop })]
+        [InlineData("{ compression : ['zstd'] }", new[] { CompressorType.ZStandard})]
         [InlineData("{ compression : [] }", new CompressorType[0])]
         [InlineData("{ }", new CompressorType[0])]
         public void Compression_should_parse_document_correctly(string json, CompressorType[] expectedCompression)

--- a/tests/MongoDB.Driver.Core.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Specifications/connection-string/ConnectionStringTestRunner.cs
@@ -91,7 +91,7 @@ namespace MongoDB.Driver.Specifications.connection_string
                             connectionString.AuthSource.Should().Be(expectedOption.Value.AsString);
                             break;
                         case "compressors":
-                            var compressors = new BsonArray(connectionString.Compressors.Select(c => c.Type.ToString().ToLowerInvariant()));
+                            var compressors = new BsonArray(connectionString.Compressors.Select(c => CompressorTypeMapper.ToServerName(c.Type)));
                             var expectedCompressors = RemoveUnsupportedCompressors(expectedOption.Value.AsBsonArray);
                             compressors.Should().Be(expectedCompressors);
                             break;


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/5fa1c0b45623434832bd923e