### PR TITLE
CSHARP-2071: Using Linq Aggregation to project the root document.

### DIFF
--- a/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
@@ -117,6 +117,8 @@ namespace MongoDB.Driver.Linq.Translators
                                 return TranslateArrayIndex((ArrayIndexExpression)node);
                             case ExtensionExpressionType.Concat:
                                 return TranslateConcat((ConcatExpression)node);
+                            case ExtensionExpressionType.Document:
+                                return TranslateDocument((DocumentExpression)node);
                             case ExtensionExpressionType.Except:
                                 return TranslateExcept((ExceptExpression)node);
                             case ExtensionExpressionType.FieldAsDocument:
@@ -249,6 +251,11 @@ namespace MongoDB.Driver.Linq.Translators
             // NOTE: there may be other instances where we should use a literal...
             // but I can't think of any yet.
             return value;
+        }
+
+        private BsonValue TranslateDocument(DocumentExpression node)
+        {
+            return "$$ROOT";
         }
 
         private BsonValue TranslateDocumentWrappedField(FieldAsDocumentExpression expression)

--- a/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
+++ b/src/MongoDB.Driver/Linq/Translators/AggregateLanguageTranslator.cs
@@ -20,7 +20,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
 using MongoDB.Bson;
 using MongoDB.Driver.Linq.Expressions;
 using MongoDB.Driver.Linq.Expressions.ResultOperators;

--- a/tests/MongoDB.Driver.Tests/IAggregateFluentExtensionsTests.cs
+++ b/tests/MongoDB.Driver.Tests/IAggregateFluentExtensionsTests.cs
@@ -180,7 +180,7 @@ namespace MongoDB.Driver.Tests
             var subject = CreateSubject()
                 .Group(x => x, g => new { Name = g.Select(x => x + " " + x.LastName).First() });
 
-            var expectedGroup = BsonDocument.Parse("{ $group : { _id : '$$ROOT', Name: { '$first' : { '$concat' : [ '$FirstName', ' ', '$LastName' ] } } } }");
+            var expectedGroup = BsonDocument.Parse("{ $group : { _id : '$$ROOT', Name : { '$first' : { '$concat' : [ { '$add' : ['$$ROOT', ' '] }, '$LastName' ] } } } }");
 
             AssertLast(subject, expectedGroup);
         }

--- a/tests/MongoDB.Driver.Tests/IAggregateFluentExtensionsTests.cs
+++ b/tests/MongoDB.Driver.Tests/IAggregateFluentExtensionsTests.cs
@@ -175,6 +175,17 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public void Group_with_document_in_key_should_generate_the_correct_document_using_expressions()
+        {
+            var subject = CreateSubject()
+                .Group(x => x, g => new { Name = g.Select(x => x + " " + x.LastName).First() });
+
+            var expectedGroup = BsonDocument.Parse("{ $group : { _id : '$$ROOT', Name: { '$first' : { '$concat' : [ '$FirstName', ' ', '$LastName' ] } } } }");
+
+            AssertLast(subject, expectedGroup);
+        }
+
+        [Fact]
         public void Lookup_should_generate_the_correct_group_when_using_BsonDocument()
         {
             var subject = CreateSubject()
@@ -267,12 +278,32 @@ namespace MongoDB.Driver.Tests
         }
 
         [Fact]
+        public void Project_with_document_should_generate_the_correct_document_using_expressions()
+        {
+            var subject = CreateSubject().Project(x => new { Name = x });
+
+            var expectedProject = BsonDocument.Parse("{ $project : { Name : '$$ROOT' , _id : 0 } }");
+
+            AssertLast(subject, expectedProject);
+        }
+
+        [Fact]
         public void ReplaceRoot_should_generate_the_correct_stage()
         {
             var subject = CreateSubject()
                 .ReplaceRoot(x => x.PhoneNumber);
 
             var expectedStage = BsonDocument.Parse("{ $replaceRoot : { newRoot:  '$PhoneNumber' } }");
+
+            AssertLast(subject, expectedStage);
+        }
+
+        [Fact]
+        public void ReplaceRoot_for_document_should_generate_the_correct_stage()
+        {
+            var subject = CreateSubject().ReplaceRoot(x => x);
+
+            var expectedStage = BsonDocument.Parse("{ $replaceRoot : { newRoot :  '$$ROOT' } }");
 
             AssertLast(subject, expectedStage);
         }
@@ -295,6 +326,16 @@ namespace MongoDB.Driver.Tests
                 .ReplaceWith(x => x.PhoneNumber);
 
             var expectedStage = BsonDocument.Parse("{ $replaceWith : '$PhoneNumber' }");
+
+            AssertLast(subject, expectedStage);
+        }
+
+        [Fact]
+        public void ReplaceWith_for_document_should_generate_the_correct_stage()
+        {
+            var subject = CreateSubject().ReplaceWith(x => x);
+
+            var expectedStage = BsonDocument.Parse("{ $replaceWith : '$$ROOT' }");
 
             AssertLast(subject, expectedStage);
         }
@@ -478,6 +519,16 @@ namespace MongoDB.Driver.Tests
                 .SortByCount(x => x.Age);
 
             var expectedStage = BsonDocument.Parse("{ $sortByCount : '$Age' }");
+
+            AssertLast(subject, expectedStage);
+        }
+
+        [Fact]
+        public void SortByCount_with_document_in_id_should_generate_the_correct_stage()
+        {
+            var subject = CreateSubject().SortByCount(x => x);
+
+            var expectedStage = BsonDocument.Parse("{ $sortByCount : '$$ROOT' }");
 
             AssertLast(subject, expectedStage);
         }

--- a/tests/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
@@ -132,6 +132,17 @@ namespace Tests.MongoDB.Driver.Linq
         }
 
         [Fact]
+        public void GroupBy_with_document_in_key()
+        {
+            var query = CreateQuery().GroupBy(x => x);
+
+            Assert(
+                query,
+                2,
+                "{ $group : { '_id' : '$$ROOT' } }");
+        }
+
+        [Fact]
         public void Count()
         {
             var result = CreateQuery().Count();
@@ -904,6 +915,17 @@ namespace Tests.MongoDB.Driver.Linq
             Assert(query,
                 2,
                 "{ $project: { Id: '$_id', A: '$A', _id: 0} }");
+        }
+
+        [Fact]
+        public void Select_for_document()
+        {
+            var query = CreateQuery().Select(x => new { Result = x } );
+
+            Assert(
+                query,
+                2,
+                "{ $project : { Result : '$$ROOT', _id : 0 } }");
         }
 
         [Fact]

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/AggregateGroupTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/AggregateGroupTranslatorTests.cs
@@ -299,6 +299,14 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             result.Value.Result.Should().Equal(111);
         }
 
+        [Fact]
+        public void Should_translate_push_with_root()
+        {
+            var result = Group(x => x.A, g => new { Result = g.Select(x => x) });
+
+            result.Projection.Should().Be("{ _id: \"$A\", Result: { \"$push\": \"$$ROOT\" } }");
+        }
+
         [SkippableFact]
         public void Should_translate_stdDevPop_with_embedded_projector()
         {

--- a/tests/MongoDB.Driver.Tests/Linq/Translators/AggregateGroupTranslatorTests.cs
+++ b/tests/MongoDB.Driver.Tests/Linq/Translators/AggregateGroupTranslatorTests.cs
@@ -299,14 +299,6 @@ namespace MongoDB.Driver.Tests.Linq.Translators
             result.Value.Result.Should().Equal(111);
         }
 
-        [Fact]
-        public void Should_translate_push_with_root()
-        {
-            var result = Group(x => x.A, g => new { Result = g.Select(x => x) });
-
-            result.Projection.Should().Be("{ _id: \"$A\", Result: { \"$push\": \"$$ROOT\" } }");
-        }
-
         [SkippableFact]
         public void Should_translate_stdDevPop_with_embedded_projector()
         {


### PR DESCRIPTION
EG:  https://evergreen.mongodb.com/version/5fd0d2ba56234307db3fa324
Original PR: https://github.com/mongodb/mongo-csharp-driver/pull/319 

NOTES: this logic potentially can affect the following commands:

    * GraphLookup
    * Bucket
    * BucketAuto
   
But for that, we need to change the way how these commands work. As far as I can see, it's impossible to break them in the current implementation. 