### PR TITLE
CSHARP-3294: Fix CreateIndexesOperationTests tests on latests.

### DIFF
--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateIndexesOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateIndexesOperationTests.cs
@@ -241,7 +241,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             RequireServer.Check();
             DropCollection();
-            var expireAfter = TimeSpan.FromSeconds(1.5);
+            var expireAfter = TimeSpan.FromSeconds(1);
             var requests = new[] { new CreateIndexRequest(new BsonDocument("x", 1)) { ExpireAfter = expireAfter } };
             var subject = new CreateIndexesOperation(_collectionNamespace, requests, _messageEncoderSettings);
 

--- a/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateIndexesUsingCommandOperationTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/Operations/CreateIndexesUsingCommandOperationTests.cs
@@ -420,7 +420,7 @@ namespace MongoDB.Driver.Core.Operations
         {
             RequireServer.Check();
             DropCollection();
-            var expireAfter = TimeSpan.FromSeconds(1.5);
+            var expireAfter = TimeSpan.FromSeconds(1);
             var requests = new[] { new CreateIndexRequest(new BsonDocument("x", 1)) { ExpireAfter = expireAfter } };
             var subject = new CreateIndexesUsingCommandOperation(_collectionNamespace, requests, _messageEncoderSettings);
 


### PR DESCRIPTION
EG: https://evergreen.mongodb.com/version/6007484632f41773714fbf88